### PR TITLE
fix(particles): drop the "+1" lie at low FPS

### DIFF
--- a/src/game/state.rs
+++ b/src/game/state.rs
@@ -475,9 +475,19 @@ impl GameState {
         self.clench_ticks = CLENCH_TICKS;
     }
 
+    /// Spawn a "+N" particle representing cuques earned since the last
+    /// auto-particle. Silently skips if there isn't a whole cuque of accrued
+    /// income to show — at low FPS the caller is a rate-based timer that
+    /// fires faster than cuques arrive, and spawning a "+1" in that window
+    /// used to lie (particle flying up while the HUD counter didn't move).
+    /// The shown amount is always real cuques that just accrued into
+    /// `visual_debt`.
     pub fn spawn_auto_particle(&mut self, col: u16, row: u16) {
-        let amount = (self.visual_debt.floor() as u64).max(1);
-        self.visual_debt = (self.visual_debt - amount as f64).max(0.0);
+        let amount = self.visual_debt.floor() as u64;
+        if amount == 0 {
+            return;
+        }
+        self.visual_debt -= amount as f64;
         self.particles.push(Particle {
             col,
             row: row as f32,


### PR DESCRIPTION
## Summary

At low FPS (e.g. 0.1 = 1 cuque per 10s), `+1` auto-particles used to fly up around the biscuit while the HUD counter sat still for seconds at a time. `spawn_auto_particle` had a `.max(1)` floor that forced a particle to claim a whole cuque even when only 0.005 of `visual_debt` had accrued.

Fix is one line: drop the floor, return early if `floor(visual_debt) == 0`. The existing probability-based rate limiter in `maybe_spawn_auto_particle` still governs _when_ particles fire; we just now refuse to fire when there's nothing real to show.

## Behavior after fix
- **0.1 FPS**: debt crosses 1 every ~10s; next probability tick (expected ~2s after) spawns one "+1". Roughly one particle every 10-12s. Matches the counter.
- **1 FPS**: debt crosses 1 every tick batch; particles fire at the rate-limited cap, each showing "+1" or "+2" depending on how much accumulated between spawns.
- **100+ FPS**: same rate-limited cap, but each particle now honestly shows a bundled "+N" representing the batch.

Clicks still spawn their own particles directly (unrelated code path) — this fix only touches fps-driven auto-particles.

## Test plan
- [x] `cargo fmt --check` ✓
- [x] `cargo clippy --all-targets -- -D warnings` ✓
- [x] `cargo test` ✓
- [x] Manual: fresh save, 20 clicks + buy Index Finger (0.10 FPS), waited 12s — no "+1" particles flying when cuques counter isn't moving. Counter ticked 5 → 7 over the interval as expected.