### PR TITLE
feat(hud): show git branch in dev builds

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,60 @@
+//! Captures the current git branch (and re-runs when it changes) and
+//! exposes it to the crate as the compile-time env var `CUQUE_GIT_BRANCH`.
+//!
+//! Used by the HUD title to mark dev builds with their branch name so
+//! side-by-side instances built from different branches are visually
+//! distinguishable. When the crate is built outside a git tree — e.g.
+//! from a crates.io tarball, `cargo install`, or a vendored source drop —
+//! no env var is set and `option_env!` at the call site yields `None`.
+//! Shipped release binaries are built from a patched-version tree inside
+//! CI's checkout, so they DO see a branch here, but their HUD already
+//! shows the real version so the branch suffix is suppressed downstream.
+
+use std::process::Command;
+
+fn main() {
+    // Rebuild if HEAD moves (new commit, branch checkout, etc.).
+    println!("cargo:rerun-if-changed=.git/HEAD");
+
+    // If HEAD points at a branch ref, also rebuild when THAT ref moves —
+    // otherwise `cargo build` after a simple `git commit` on the current
+    // branch wouldn't notice.
+    if let Ok(out) = Command::new("git")
+        .args(["symbolic-ref", "-q", "HEAD"])
+        .output()
+        && out.status.success()
+        && let Ok(s) = std::str::from_utf8(&out.stdout)
+    {
+        let refpath = s.trim();
+        if !refpath.is_empty() {
+            println!("cargo:rerun-if-changed=.git/{refpath}");
+        }
+    }
+
+    // Branch name. On detached HEAD `--abbrev-ref HEAD` returns "HEAD";
+    // fall back to a short SHA so the HUD still has something useful.
+    let branch = Command::new("git")
+        .args(["rev-parse", "--abbrev-ref", "HEAD"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty());
+    let label = match branch {
+        Some(b) if b != "HEAD" => Some(b),
+        _ => Command::new("git")
+            .args(["rev-parse", "--short", "HEAD"])
+            .output()
+            .ok()
+            .filter(|o| o.status.success())
+            .and_then(|o| String::from_utf8(o.stdout).ok())
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty()),
+    };
+    if let Some(label) = label {
+        println!("cargo:rustc-env=CUQUE_GIT_BRANCH={label}");
+    }
+    // If both git commands failed (no git tree, no git installed) we simply
+    // don't set the env var — the HUD renders without a branch suffix.
+}

--- a/src/build_info.rs
+++ b/src/build_info.rs
@@ -7,3 +7,9 @@ pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 pub fn is_dev_build() -> bool {
     VERSION == "0.0.0"
 }
+
+/// Git branch (or short SHA on detached HEAD) captured by `build.rs` at
+/// compile time. `None` when built outside a git tree — e.g. a crates.io
+/// tarball or a vendored source drop — so release paths don't need special
+/// handling. Used by the HUD to mark dev builds with their source branch.
+pub const GIT_BRANCH: Option<&str> = option_env!("CUQUE_GIT_BRANCH");

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -22,7 +22,13 @@ const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 fn hud_title() -> String {
     if VERSION == "0.0.0" {
-        " CuqueClicker v0.0.0 (dev) ".into()
+        // Dev builds include the git branch (or short SHA on detached HEAD)
+        // so two instances built from different branches can be told apart
+        // at a glance — useful for side-by-side comparison.
+        match crate::build_info::GIT_BRANCH {
+            Some(branch) => format!(" CuqueClicker v0.0.0 (dev, {branch}) "),
+            None => " CuqueClicker v0.0.0 (dev) ".into(),
+        }
     } else {
         format!(" CuqueClicker v{VERSION} ")
     }


### PR DESCRIPTION
## Summary

Dev builds (Cargo.toml version `0.0.0`) now show the current git branch in the HUD title:

```
CuqueClicker v0.0.0 (dev, feat/dev-branch-hud)
```

Useful for running two builds from different branches side-by-side — different saves via `XDG_CONFIG_HOME=…`, different terminals, and now visually distinguishable at a glance.

## How

- `build.rs` runs at compile time, calls `git rev-parse --abbrev-ref HEAD`, emits `cargo:rustc-env=CUQUE_GIT_BRANCH=<branch>`. Also emits `cargo:rerun-if-changed=.git/HEAD` and the current branch ref so a new commit forces a rebuild (mostly matters for the detached-HEAD short-SHA fallback).
- On detached HEAD the label falls back to a short commit SHA.
- Built outside a git tree (crates.io tarball, `cargo install`, vendored source)? The env var is simply not set, `option_env!` yields `None`, HUD renders the plain `(dev)` suffix unchanged. No new dep, no failure mode for release paths.
- Only dev builds show the branch. Release builds (patched version) continue to show just `v0.1.1`.

## Test plan
- [x] `cargo fmt --check` / `cargo clippy -D warnings` / `cargo test` ✓
- [x] Manual via `tu`: HUD reads `CuqueClicker v0.0.0 (dev, feat/dev-branch-hud)` after `cargo build --release` from this branch.
- [x] After merge, rebuild main and `feat/sim-thread` — each should show its own branch name, making the comparison rig unambiguous.