### PR TITLE
fix: super bug fixeroo — closes #6, #7, #8, #9, #10

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -612,9 +612,18 @@ fn handle_click(
     // Golden cuques are catchable from ANY panel — match the keyboard 'g'
     // behavior, which has no mode guard. The marker still renders on the
     // biscuit while a non-Game panel is open, so the user expects clicking
-    // it to work regardless. This MUST stay above the mode-gate below.
+    // it to work regardless.
     if rect_contains(golden, col, row) {
         let _ = tx.send(Action::CatchGolden);
+        return;
+    }
+    // Clicking the biscuit itself is also mode-agnostic: the ass is always
+    // visible in the left column, and the user's reasonable expectation is
+    // that fingering works regardless of which panel is open on the right.
+    // (Mode-specific rows in the right column come AFTER, so a panel-row
+    // click is never confused for a biscuit click.)
+    if rect_contains(biscuit, col, row) {
+        let _ = tx.send(Action::Click { col, row });
         return;
     }
     // Mouse-buy fingerers from the sidebar in Game mode. Modifiers control
@@ -630,10 +639,6 @@ fn handle_click(
                 return;
             }
         }
-        if rect_contains(biscuit, col, row) {
-            let _ = tx.send(Action::Click { col, row });
-        }
-        return;
     }
     // Mouse-buy upgrades from the Upgrades panel. Modifiers ignored — each
     // upgrade is a one-shot purchase.
@@ -733,12 +738,15 @@ fn handle_key(
             *zoom_idx = (*zoom_idx + 1).min(crate::ui::biscuit::level_count() - 1);
         }
         KeyCode::Char(' ') | KeyCode::Enter => {
-            if *mode == Mode::Prestige {
-                if current.prestige_available() > 0 {
-                    let _ = tx.send(Action::PrestigeReset);
-                    *mode = Mode::Game;
-                }
-            } else if *mode == Mode::Game {
+            // Inside the Prestige panel Space/Enter confirms the reset
+            // (when one is available). Everywhere else — including any
+            // non-Game panel — Space/Enter fingers the cuque, matching the
+            // mouse-click-anywhere-on-biscuit behavior. The ass is always
+            // clickable.
+            if *mode == Mode::Prestige && current.prestige_available() > 0 {
+                let _ = tx.send(Action::PrestigeReset);
+                *mode = Mode::Game;
+            } else if *mode != Mode::Prestige {
                 let _ = tx.send(Action::ClickCenter);
             }
         }

--- a/src/app.rs
+++ b/src/app.rs
@@ -737,18 +737,13 @@ fn handle_key(
         KeyCode::Char('-') | KeyCode::Char('_') => {
             *zoom_idx = (*zoom_idx + 1).min(crate::ui::biscuit::level_count() - 1);
         }
-        KeyCode::Char(' ') | KeyCode::Enter => {
-            // Inside the Prestige panel Space/Enter confirms the reset
-            // (when one is available). Everywhere else — including any
-            // non-Game panel — Space/Enter fingers the cuque, matching the
-            // mouse-click-anywhere-on-biscuit behavior. The ass is always
-            // clickable.
-            if *mode == Mode::Prestige && current.prestige_available() > 0 {
-                let _ = tx.send(Action::PrestigeReset);
-                *mode = Mode::Game;
-            } else if *mode != Mode::Prestige {
-                let _ = tx.send(Action::ClickCenter);
-            }
+        // Space ALWAYS fingers the cuque, regardless of which panel is open
+        // — same contract as left-click on the biscuit. Enter is reserved
+        // (no-op here) so future menu/dialog work can use it as the global
+        // "accept" key without overloading meaning. The Prestige panel uses
+        // [r] alone to confirm a reset.
+        KeyCode::Char(' ') => {
+            let _ = tx.send(Action::ClickCenter);
         }
         KeyCode::Char(c) => {
             if let Some((slot, shifted_sym)) = digit_slot(c) {

--- a/src/app.rs
+++ b/src/app.rs
@@ -46,7 +46,9 @@ use std::sync::{
 use std::thread;
 use std::time::{Duration, Instant};
 
+use crate::game::achievement::ACHIEVEMENTS;
 use crate::game::fingerer;
+use crate::game::fingerer::FINGERERS;
 use crate::game::golden::{self, GoldenVariant};
 use crate::game::state::{GameState, TICK_DT, TICK_HZ};
 use crate::game::upgrade::UPGRADES;
@@ -163,8 +165,8 @@ impl App {
         let mut mode = Mode::Game;
         let mut zoom_idx: usize = 0;
         let mut running = true;
-        let mut visible_upgrades: Vec<usize> = Vec::new();
-        let mut visible_fingerers: Vec<usize> = Vec::new();
+        let mut upgrade_rows: Vec<(usize, Rect)> = Vec::new();
+        let mut fingerer_rows: Vec<(usize, Rect)> = Vec::new();
         let mut biscuit_rect = Rect::default();
         let mut golden_rect = Rect::default();
 
@@ -183,8 +185,8 @@ impl App {
                 let out = ui::draw(f, &current, mode, zoom_idx, debug);
                 biscuit_rect = out.biscuit_rect;
                 golden_rect = out.golden_rect;
-                visible_upgrades = out.visible_upgrades;
-                visible_fingerers = out.visible_fingerers;
+                upgrade_rows = out.upgrade_rows;
+                fingerer_rows = out.fingerer_rows;
             })?;
 
             // Hand fresh geometry to the sim. Ordering is preserved by mpsc,
@@ -202,8 +204,8 @@ impl App {
                         &mut mode,
                         &mut zoom_idx,
                         &mut running,
-                        &visible_fingerers,
-                        &visible_upgrades,
+                        &fingerer_rows,
+                        &upgrade_rows,
                         debug,
                         &current,
                         biscuit_rect,
@@ -305,13 +307,13 @@ fn apply_action(state: &mut GameState, action: Action, geom: &mut SimGeometry) {
                 && row >= r.y
                 && row < r.y + r.height
             {
-                state.click((col, row));
+                state.click((col, row), r);
             }
         }
         Action::ClickCenter => {
             let r = geom.biscuit;
             if r.width > 0 && r.height > 0 {
-                state.click((r.x + r.width / 2, r.y + r.height / 2));
+                state.click((r.x + r.width / 2, r.y + r.height / 2), r);
             }
         }
         Action::CatchGolden => {
@@ -399,11 +401,11 @@ fn maybe_spawn_auto_particle(state: &mut GameState, geom: &SimGeometry) {
     if rng.random::<f64>() >= prob {
         return;
     }
-    let col =
-        rng.random_range(geom.biscuit.x + 1..geom.biscuit.x + geom.biscuit.width.saturating_sub(2));
-    let row = rng
-        .random_range(geom.biscuit.y + 1..geom.biscuit.y + geom.biscuit.height.saturating_sub(1));
-    state.spawn_auto_particle(col, row);
+    // Random anchor within the biscuit, with a small inset so the "+N" text
+    // doesn't clip into the border.
+    let frac_x = rng.random_range(0.05_f32..=0.95);
+    let frac_y = rng.random_range(0.10_f32..=0.95);
+    state.spawn_auto_particle(frac_x, frac_y);
 }
 
 fn maybe_spawn_golden(state: &mut GameState, geom: &SimGeometry) {
@@ -413,30 +415,14 @@ fn maybe_spawn_golden(state: &mut GameState, geom: &SimGeometry) {
     if geom.biscuit.width < 8 || geom.biscuit.height < 5 {
         return;
     }
-    let col_range = (
-        geom.biscuit.x + 2,
-        geom.biscuit.x + geom.biscuit.width.saturating_sub(8),
-    );
-    let row_range = (
-        geom.biscuit.y + 1,
-        geom.biscuit.y + geom.biscuit.height.saturating_sub(4),
-    );
-    state.golden = Some(golden::spawn_in(col_range, row_range));
+    state.golden = Some(golden::spawn_in(geom.biscuit));
 }
 
 fn force_spawn_golden(state: &mut GameState, geom: &SimGeometry, variant: GoldenVariant) {
     if geom.biscuit.width < 8 || geom.biscuit.height < 5 {
         return;
     }
-    let col_range = (
-        geom.biscuit.x + 2,
-        geom.biscuit.x + geom.biscuit.width.saturating_sub(8),
-    );
-    let row_range = (
-        geom.biscuit.y + 1,
-        geom.biscuit.y + geom.biscuit.height.saturating_sub(4),
-    );
-    let mut g = golden::spawn_in(col_range, row_range);
+    let mut g = golden::spawn_in(geom.biscuit);
     g.variant = variant;
     state.golden = Some(g);
 }
@@ -460,7 +446,7 @@ fn demo_driver_tick(
     if t.is_multiple_of(13) {
         let r = geom.biscuit;
         if r.width > 0 && r.height > 0 {
-            state.click((r.x + r.width / 2, r.y + r.height / 2));
+            state.click((r.x + r.width / 2, r.y + r.height / 2), r);
         }
     }
 
@@ -548,8 +534,8 @@ fn handle_event(
     mode: &mut Mode,
     zoom_idx: &mut usize,
     running: &mut bool,
-    visible_fingerers: &[usize],
-    visible_upgrades: &[usize],
+    fingerer_rows: &[(usize, Rect)],
+    upgrade_rows: &[(usize, Rect)],
     debug: bool,
     current: &GameState,
     biscuit_rect: Rect,
@@ -562,13 +548,23 @@ fn handle_event(
             mode,
             zoom_idx,
             running,
-            visible_fingerers,
-            visible_upgrades,
+            fingerer_rows,
+            upgrade_rows,
             debug,
             current,
         ),
         Event::Mouse(m) if m.kind == MouseEventKind::Down(MouseButton::Left) => {
-            handle_click(m.column, m.row, tx, *mode, biscuit_rect, golden_rect);
+            handle_click(
+                m.column,
+                m.row,
+                m.modifiers,
+                tx,
+                *mode,
+                biscuit_rect,
+                golden_rect,
+                fingerer_rows,
+                upgrade_rows,
+            );
         }
         Event::Mouse(m) if m.kind == MouseEventKind::ScrollUp => {
             let _ = m;
@@ -582,32 +578,72 @@ fn handle_event(
     }
 }
 
+fn rect_contains(rect: Rect, col: u16, row: u16) -> bool {
+    rect.width > 0
+        && rect.height > 0
+        && col >= rect.x
+        && col < rect.x + rect.width
+        && row >= rect.y
+        && row < rect.y + rect.height
+}
+
+fn click_buy_qty(mods: KeyModifiers) -> BuyQty {
+    if mods.contains(KeyModifiers::ALT) || mods.contains(KeyModifiers::CONTROL) {
+        BuyQty::Max
+    } else if mods.contains(KeyModifiers::SHIFT) {
+        BuyQty::Ten
+    } else {
+        BuyQty::One
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
 fn handle_click(
     col: u16,
     row: u16,
+    mods: KeyModifiers,
     tx: &mpsc::Sender<Action>,
     mode: Mode,
     biscuit: Rect,
     golden: Rect,
+    fingerer_rows: &[(usize, Rect)],
+    upgrade_rows: &[(usize, Rect)],
 ) {
-    if mode != Mode::Game {
-        return;
-    }
-    if golden.width > 0
-        && col >= golden.x
-        && col < golden.x + golden.width
-        && row >= golden.y
-        && row < golden.y + golden.height
-    {
+    // Golden cuques are catchable from ANY panel — match the keyboard 'g'
+    // behavior, which has no mode guard. The marker still renders on the
+    // biscuit while a non-Game panel is open, so the user expects clicking
+    // it to work regardless. This MUST stay above the mode-gate below.
+    if rect_contains(golden, col, row) {
         let _ = tx.send(Action::CatchGolden);
         return;
     }
-    if col >= biscuit.x
-        && col < biscuit.x + biscuit.width
-        && row >= biscuit.y
-        && row < biscuit.y + biscuit.height
-    {
-        let _ = tx.send(Action::Click { col, row });
+    // Mouse-buy fingerers from the sidebar in Game mode. Modifiers control
+    // quantity (plain = 1, Shift = 10, Alt/Ctrl = max), matching the
+    // digit-key shortcuts so the two input methods stay symmetric.
+    if mode == Mode::Game {
+        for &(idx, r) in fingerer_rows {
+            if rect_contains(r, col, row) {
+                let _ = tx.send(Action::BuyFingerer {
+                    idx,
+                    qty: click_buy_qty(mods),
+                });
+                return;
+            }
+        }
+        if rect_contains(biscuit, col, row) {
+            let _ = tx.send(Action::Click { col, row });
+        }
+        return;
+    }
+    // Mouse-buy upgrades from the Upgrades panel. Modifiers ignored — each
+    // upgrade is a one-shot purchase.
+    if mode == Mode::Upgrades {
+        for &(idx, r) in upgrade_rows {
+            if rect_contains(r, col, row) {
+                let _ = tx.send(Action::BuyUpgrade(idx));
+                return;
+            }
+        }
     }
 }
 
@@ -618,8 +654,8 @@ fn handle_key(
     mode: &mut Mode,
     zoom_idx: &mut usize,
     running: &mut bool,
-    visible_fingerers: &[usize],
-    visible_upgrades: &[usize],
+    fingerer_rows: &[(usize, Rect)],
+    upgrade_rows: &[(usize, Rect)],
     debug: bool,
     current: &GameState,
 ) {
@@ -713,7 +749,7 @@ fn handle_key(
                     mods.contains(KeyModifiers::ALT) || mods.contains(KeyModifiers::CONTROL);
                 match *mode {
                     Mode::Game => {
-                        if let Some(&fid) = visible_fingerers.get(slot) {
+                        if let Some(&(fid, _)) = fingerer_rows.get(slot) {
                             let qty = if buy_max {
                                 BuyQty::Max
                             } else if buy_10 {
@@ -725,7 +761,7 @@ fn handle_key(
                         }
                     }
                     Mode::Upgrades => {
-                        if let Some(&u_idx) = visible_upgrades.get(slot) {
+                        if let Some(&(u_idx, _)) = upgrade_rows.get(slot) {
                             let _ = tx.send(Action::BuyUpgrade(u_idx));
                         }
                     }
@@ -762,46 +798,30 @@ pub fn build_demo_state() -> GameState {
         best_fps: 50_000.0,
         ..GameState::default()
     };
-    // 3+ rings of hands around the biscuit. Per-type cap in `ui/hands.rs`
-    // is 40, so anything over 40 is visually identical. 8 types owned =
-    // thick crust of hands around the ass.
-    for (id, count) in [
-        ("index_finger", 40),
-        ("whole_hand", 40),
-        ("latex_glove", 35),
-        ("greek_kiss", 30),
-        ("robotic_finger", 25),
-        ("tentacle", 20),
-        ("finger_vortex", 15),
-        ("dimensional_hole", 10),
-    ] {
-        s.fingerers_owned.insert(id.into(), count);
+    // Seed counts/flags BY CATALOG INDEX rather than by hardcoded id strings,
+    // so a future rename/reorder/removal of a fingerer or upgrade can never
+    // silently degrade the demo (the live id at that slot is always used).
+    //
+    // Per-tier owned counts ramp down 40→10 across the first 8 fingerers.
+    // The per-type cap in `ui/hands.rs` is 40, so anything beyond that is
+    // visually identical — 8 types owned = thick crust of hands.
+    const DEMO_FINGERER_COUNTS: &[u32] = &[40, 40, 35, 30, 25, 20, 15, 10];
+    for (idx, &count) in DEMO_FINGERER_COUNTS.iter().enumerate() {
+        if let Some(f) = FINGERERS.get(idx)
+            && count > 0
+        {
+            s.fingerers_owned.insert(f.id.to_string(), count);
+        }
     }
-    // A spread of upgrades so the sidebar shows (xN) multipliers on several tiers.
-    for id in [
-        "click_mult_1",
-        "click_mult_2",
-        "index_finger_mult_1",
-        "index_finger_mult_2",
-        "whole_hand_mult_1",
-        "whole_hand_mult_2",
-        "latex_glove_mult_1",
-        "latex_glove_mult_2",
-        "robotic_finger_mult_1",
-        "all_fingerers_boost",
-    ] {
-        s.upgrades_earned.insert(id.into());
+    // Take the first 10 upgrades from the catalog (deterministic regardless
+    // of how UPGRADES is reordered) — gives a spread of click + per-tier
+    // multipliers so the sidebar shows (xN) on several tiers.
+    for u in UPGRADES.iter().take(10) {
+        s.upgrades_earned.insert(u.id.to_string());
     }
-    // A handful of achievements for visual variety in that panel.
-    for id in [
-        "first_finger",
-        "warming_up",
-        "seasoned_fingerer",
-        "automation",
-        "factory_of_fingers",
-        "golden_touch",
-    ] {
-        s.achievements_earned.insert(id.into());
+    // First 6 achievements for visual variety in that panel.
+    for a in ACHIEVEMENTS.iter().take(6) {
+        s.achievements_earned.insert(a.id.to_string());
     }
     s
 }

--- a/src/game/golden.rs
+++ b/src/game/golden.rs
@@ -1,4 +1,5 @@
 use rand::RngExt;
+use ratatui::layout::Rect;
 
 /// A Golden Cuque variant. The on-screen marker color + label differ per
 /// variant, but all are caught through the same path (mouse click on the
@@ -27,10 +28,14 @@ impl GoldenVariant {
     }
 }
 
+/// Position is stored as a fraction of the biscuit rect ([0.0, 1.0] on each
+/// axis) so the marker stays anchored to its spot on the biscuit when the
+/// terminal resizes or the user zooms (`+`/`-`). The renderer resolves these
+/// fractions against the *current* biscuit rect every frame.
 #[derive(Clone)]
 pub struct GoldenCuque {
-    pub col: u16,
-    pub row: u16,
+    pub frac_x: f32,
+    pub frac_y: f32,
     pub life_ticks: u32,
     pub variant: GoldenVariant,
 }
@@ -38,18 +43,25 @@ pub struct GoldenCuque {
 pub const GOLDEN_LIFE_TICKS: u32 = 220; // ~11s at 20Hz
 pub const GOLDEN_COOLDOWN_MIN: u32 = 400; // 20s
 pub const GOLDEN_COOLDOWN_MAX: u32 = 1600; // 80s
+// Inset (in fractional units) the spawn lottery away from the biscuit edges
+// so the 5x3 marker has room to render without bumping into the border.
+const SPAWN_INSET_X: f32 = 0.08;
+const SPAWN_INSET_Y: f32 = 0.10;
 
 pub fn next_cooldown() -> u32 {
     rand::rng().random_range(GOLDEN_COOLDOWN_MIN..=GOLDEN_COOLDOWN_MAX)
 }
 
-pub fn spawn_in(area_col_range: (u16, u16), area_row_range: (u16, u16)) -> GoldenCuque {
+/// Pick a random fractional position inside the biscuit, away from the edges.
+/// `_biscuit` is taken so the signature documents intent (the spawn area is
+/// "inside this rect"); the actual fractions are rect-independent.
+pub fn spawn_in(_biscuit: Rect) -> GoldenCuque {
     let mut r = rand::rng();
-    let col = r.random_range(area_col_range.0..=area_col_range.1.max(area_col_range.0));
-    let row = r.random_range(area_row_range.0..=area_row_range.1.max(area_row_range.0));
+    let frac_x = r.random_range(SPAWN_INSET_X..=(1.0 - SPAWN_INSET_X));
+    let frac_y = r.random_range(SPAWN_INSET_Y..=(1.0 - SPAWN_INSET_Y));
     GoldenCuque {
-        col,
-        row,
+        frac_x,
+        frac_y,
         life_ticks: GOLDEN_LIFE_TICKS,
         variant: GoldenVariant::random(),
     }

--- a/src/game/state.rs
+++ b/src/game/state.rs
@@ -13,10 +13,12 @@ pub const TICK_DT: f64 = 1.0 / TICK_HZ as f64;
 const CLENCH_TICKS: u32 = 3;
 const PARTICLE_LIFE: u32 = 20;
 /// Per-tick upward drift for a particle, expressed as a fraction of the
-/// biscuit's height. ~0.022 ≈ 0.4 cells/tick on a 20-row biscuit, ≈ 0.7
-/// cells/tick on a 32-row biscuit — i.e. particles always rise across roughly
-/// the same proportion of the biscuit, regardless of zoom.
-const PARTICLE_FRAC_RISE: f32 = 0.022;
+/// biscuit's height. Calibrated to match the original feel before the
+/// switch to fractional anchors: the old code rose 0.18 cells/tick on
+/// any biscuit size; on a typical ~30-row biscuit that's 0.006 of height
+/// per tick — slow enough that a "+1" only travels ~10-12% of the biscuit
+/// across its 1-second life, instead of streaking across half of it.
+const PARTICLE_FRAC_RISE: f32 = 0.006;
 const GOLDEN_REWARD_SECONDS: f64 = 60.0;
 const GOLDEN_REWARD_FLAT: f64 = 10.0;
 

--- a/src/game/state.rs
+++ b/src/game/state.rs
@@ -1,5 +1,6 @@
 use std::collections::{HashMap, HashSet};
 
+use ratatui::layout::Rect;
 use serde::{Deserialize, Serialize};
 
 use crate::game::achievement::ACHIEVEMENTS;
@@ -11,16 +12,46 @@ pub const TICK_HZ: u32 = 20;
 pub const TICK_DT: f64 = 1.0 / TICK_HZ as f64;
 const CLENCH_TICKS: u32 = 3;
 const PARTICLE_LIFE: u32 = 20;
-const PARTICLE_RISE: f32 = 0.18;
+/// Per-tick upward drift for a particle, expressed as a fraction of the
+/// biscuit's height. ~0.022 ≈ 0.4 cells/tick on a 20-row biscuit, ≈ 0.7
+/// cells/tick on a 32-row biscuit — i.e. particles always rise across roughly
+/// the same proportion of the biscuit, regardless of zoom.
+const PARTICLE_FRAC_RISE: f32 = 0.022;
 const GOLDEN_REWARD_SECONDS: f64 = 60.0;
 const GOLDEN_REWARD_FLAT: f64 = 10.0;
 
+/// Position is stored as a fraction of the biscuit rect ([0.0, 1.0] on each
+/// axis), matching `GoldenCuque`. The renderer resolves these fractions
+/// against the *current* biscuit rect every frame, so particles travel with
+/// the biscuit when the terminal resizes or the user zooms.
 #[derive(Clone)]
 pub struct Particle {
-    pub col: u16,
-    pub row: f32,
+    pub frac_x: f32,
+    pub frac_y: f32,
     pub life: u32,
     pub text: String,
+}
+
+/// Convert an absolute `(col, row)` screen point into biscuit-fractional
+/// coordinates, clamped to [0.0, 1.0]. Used at click/spawn sites that come
+/// from screen-space input (mouse clicks, RNG within the biscuit rect).
+pub fn screen_to_biscuit_frac(col: u16, row: u16, biscuit: Rect) -> (f32, f32) {
+    if biscuit.width == 0 || biscuit.height == 0 {
+        return (0.5, 0.5);
+    }
+    let fx = ((col as i32 - biscuit.x as i32) as f32) / biscuit.width as f32;
+    let fy = ((row as i32 - biscuit.y as i32) as f32) / biscuit.height as f32;
+    (fx.clamp(0.0, 1.0), fy.clamp(0.0, 1.0))
+}
+
+/// Convert biscuit-fractional coordinates back to an absolute screen point.
+pub fn biscuit_frac_to_screen(frac_x: f32, frac_y: f32, biscuit: Rect) -> (u16, u16) {
+    let col = biscuit.x as f32 + frac_x.clamp(0.0, 1.0) * biscuit.width as f32;
+    let row = biscuit.y as f32 + frac_y.clamp(0.0, 1.0) * biscuit.height as f32;
+    (
+        col.round().clamp(0.0, u16::MAX as f32) as u16,
+        row.round().clamp(0.0, u16::MAX as f32) as u16,
+    )
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -227,17 +258,18 @@ impl GameState {
 
     // -- Click / tick -------------------------------------------------------
 
-    pub fn click(&mut self, origin: (u16, u16)) {
+    pub fn click(&mut self, origin: (u16, u16), biscuit: Rect) {
         let power = self.click_power();
         self.add_cuques(power);
         self.total_clicks += 1;
         self.clench_ticks = CLENCH_TICKS;
         let jitter = (self.total_clicks as i32 % 9) - 4;
         let col = (origin.0 as i32 + jitter).max(0) as u16;
-        let row = (origin.1 as f32) - 1.0;
+        let row = origin.1.saturating_sub(1);
+        let (frac_x, frac_y) = screen_to_biscuit_frac(col, row, biscuit);
         self.particles.push(Particle {
-            col,
-            row,
+            frac_x,
+            frac_y,
             life: PARTICLE_LIFE,
             text: format!("+{}", crate::format::big(power)),
         });
@@ -349,8 +381,8 @@ impl GameState {
             }
         };
         self.particles.push(Particle {
-            col: golden.col,
-            row: golden.row as f32,
+            frac_x: golden.frac_x,
+            frac_y: golden.frac_y,
             life: PARTICLE_LIFE * 2,
             text: label,
         });
@@ -441,7 +473,7 @@ impl GameState {
         self.clench_ticks = self.clench_ticks.saturating_sub(1);
         for p in self.particles.iter_mut() {
             p.life = p.life.saturating_sub(1);
-            p.row -= PARTICLE_RISE;
+            p.frac_y -= PARTICLE_FRAC_RISE;
         }
         self.particles.retain(|p| p.life > 0);
         self.session_ticks += 1;
@@ -482,15 +514,15 @@ impl GameState {
     /// used to lie (particle flying up while the HUD counter didn't move).
     /// The shown amount is always real cuques that just accrued into
     /// `visual_debt`.
-    pub fn spawn_auto_particle(&mut self, col: u16, row: u16) {
+    pub fn spawn_auto_particle(&mut self, frac_x: f32, frac_y: f32) {
         let amount = self.visual_debt.floor() as u64;
         if amount == 0 {
             return;
         }
         self.visual_debt -= amount as f64;
         self.particles.push(Particle {
-            col,
-            row: row as f32,
+            frac_x,
+            frac_y,
             life: PARTICLE_LIFE,
             text: format!("+{}", crate::format::big(amount as f64)),
         });
@@ -619,5 +651,59 @@ mod tests {
         assert_eq!(m.fingerer_count("index_finger"), 7);
         assert!(m.has_upgrade("click_mult_1"));
         assert!(m.has_achievement("first_finger"));
+    }
+
+    fn r(x: u16, y: u16, w: u16, h: u16) -> Rect {
+        Rect {
+            x,
+            y,
+            width: w,
+            height: h,
+        }
+    }
+
+    #[test]
+    fn frac_screen_roundtrip_at_corners() {
+        let biscuit = r(10, 5, 40, 20);
+        // top-left corner
+        let (fx, fy) = screen_to_biscuit_frac(10, 5, biscuit);
+        assert!(fx <= 0.001 && fy <= 0.001);
+        let (col, row) = biscuit_frac_to_screen(fx, fy, biscuit);
+        assert_eq!((col, row), (10, 5));
+
+        // bottom-right (one beyond, clamps)
+        let (fx, fy) = screen_to_biscuit_frac(50, 25, biscuit);
+        assert!(fx >= 0.999 && fy >= 0.999);
+
+        // exact center
+        let (col, row) = biscuit_frac_to_screen(0.5, 0.5, biscuit);
+        assert_eq!(col, 30);
+        assert_eq!(row, 15);
+    }
+
+    #[test]
+    fn frac_position_survives_biscuit_move() {
+        // A point at fraction (0.25, 0.5) of the biscuit must resolve to a
+        // proportionally-shifted absolute coord when the biscuit moves /
+        // grows.
+        let small = r(0, 0, 40, 20);
+        let (col_a, row_a) = biscuit_frac_to_screen(0.25, 0.5, small);
+        let large = r(10, 5, 80, 40);
+        let (col_b, row_b) = biscuit_frac_to_screen(0.25, 0.5, large);
+        // Same fractional spot, very different screen coords.
+        assert_ne!((col_a, row_a), (col_b, row_b));
+        // And the shifted point should still sit at the 25%/50% mark of the
+        // new rect.
+        assert_eq!(col_b, 30); // 10 + 0.25 * 80
+        assert_eq!(row_b, 25); // 5  + 0.5  * 40
+    }
+
+    #[test]
+    fn zero_size_biscuit_doesnt_panic() {
+        let zero = r(0, 0, 0, 0);
+        let (fx, fy) = screen_to_biscuit_frac(5, 5, zero);
+        assert_eq!((fx, fy), (0.5, 0.5));
+        let (col, row) = biscuit_frac_to_screen(0.5, 0.5, zero);
+        assert_eq!((col, row), (0, 0));
     }
 }

--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -183,9 +183,9 @@ pub const EN: Lang = Lang {
     prestige_bonus_label: "FPS bonus",
     prestige_available_label: "Available to claim",
     prestige_lifetime_needed: "Next papel at",
-    prestige_confirm_hint: "Press [Enter] or [r] to reset and claim",
+    prestige_confirm_hint: "Press [r] to reset and claim",
     prestige_not_enough: "Earn more lifetime cuques to claim.\nFormula: sqrt(lifetime / 1,000,000)",
-    help_prestige: "[p/Esc] back  [Enter/r] reset & claim  [q] quit",
+    help_prestige: "[p/Esc] back  [r] reset & claim  [q] quit",
 };
 
 pub const PT_BR: Lang = Lang {
@@ -328,9 +328,9 @@ pub const PT_BR: Lang = Lang {
     prestige_bonus_label: "Bônus de FPS",
     prestige_available_label: "Disponível para resgatar",
     prestige_lifetime_needed: "Próximo papel em",
-    prestige_confirm_hint: "Pressione [Enter] ou [r] para resetar e resgatar",
+    prestige_confirm_hint: "Pressione [r] para resetar e resgatar",
     prestige_not_enough: "Acumule mais cuques totais para resgatar.\nFórmula: raiz(total / 1.000.000)",
-    help_prestige: "[p/Esc] voltar  [Enter/r] resetar & resgatar  [q] sair",
+    help_prestige: "[p/Esc] voltar  [r] resetar & resgatar  [q] sair",
 };
 
 static LANG: OnceLock<&'static Lang> = OnceLock::new();

--- a/src/ui/biscuit.rs
+++ b/src/ui/biscuit.rs
@@ -132,7 +132,12 @@ pub fn draw(frame: &mut Frame, area: Rect, clenched: bool, zoom_idx: usize) -> R
     rect
 }
 
-pub fn draw_golden(frame: &mut Frame, golden: &GoldenCuque) -> Rect {
+/// Render the golden cuque marker. Position is resolved against the CURRENT
+/// `biscuit` rect every frame from the golden's stored fractional anchor —
+/// so the marker travels with the biscuit on zoom and resize, instead of
+/// stranding in the old screen position. Returned `Rect` is the actual
+/// drawn rect, used by the click router for hit-testing.
+pub fn draw_golden(frame: &mut Frame, golden: &GoldenCuque, biscuit: Rect) -> Rect {
     let buf = frame.buffer_mut();
     let (center, style) = match golden.variant {
         GoldenVariant::Lucky => (
@@ -167,23 +172,33 @@ pub fn draw_golden(frame: &mut Frame, golden: &GoldenCuque) -> Rect {
     let h: u16 = 3;
 
     let area = buf.area;
-    if area.width == 0 || area.height == 0 {
+    if area.width == 0 || area.height == 0 || biscuit.width < w || biscuit.height < h {
         return Rect::default();
     }
 
-    let mut col = golden.col;
-    let mut row = golden.row;
+    let (anchor_col, anchor_row) =
+        crate::game::state::biscuit_frac_to_screen(golden.frac_x, golden.frac_y, biscuit);
+    let mut col = anchor_col;
+    let mut row = anchor_row;
+    // Keep the 5x3 marker fully inside the biscuit so it never overlaps the
+    // sidebar / HUD chrome, then clamp once more to the screen for safety.
+    if col + w > biscuit.x + biscuit.width {
+        col = (biscuit.x + biscuit.width).saturating_sub(w);
+    }
+    if row + h > biscuit.y + biscuit.height {
+        row = (biscuit.y + biscuit.height).saturating_sub(h);
+    }
+    if col < biscuit.x {
+        col = biscuit.x;
+    }
+    if row < biscuit.y {
+        row = biscuit.y;
+    }
     if col + w > area.x + area.width {
         col = (area.x + area.width).saturating_sub(w);
     }
     if row + h > area.y + area.height {
         row = (area.y + area.height).saturating_sub(h);
-    }
-    if col < area.x {
-        col = area.x;
-    }
-    if row < area.y {
-        row = area.y;
     }
 
     for (dy, line) in lines.iter().enumerate() {

--- a/src/ui/effects.rs
+++ b/src/ui/effects.rs
@@ -1,18 +1,24 @@
 use ratatui::prelude::*;
 
-use crate::game::state::Particle;
+use crate::game::state::{Particle, biscuit_frac_to_screen};
 
 const PARTICLE_LIFE_F: f32 = 20.0;
 
-pub fn draw_particles(frame: &mut Frame, area: Rect, particles: &[Particle]) {
+/// Render auto/click particles. Positions are resolved against the CURRENT
+/// `biscuit` rect from each particle's fractional anchor, so they travel
+/// with the biscuit on zoom/resize. `area` (the biscuit rect, same as the
+/// resolution target) is the visual clip.
+pub fn draw_particles(frame: &mut Frame, biscuit: Rect, particles: &[Particle]) {
+    if biscuit.width == 0 || biscuit.height == 0 {
+        return;
+    }
     let buf = frame.buffer_mut();
     for p in particles {
-        let r = p.row.round();
-        if r < area.y as f32 || r >= (area.y + area.height) as f32 {
+        let (col, row) = biscuit_frac_to_screen(p.frac_x, p.frac_y, biscuit);
+        if row < biscuit.y || row >= biscuit.y + biscuit.height {
             continue;
         }
-        let row = r as u16;
-        if p.col < area.x || p.col >= area.x + area.width {
+        if col < biscuit.x || col >= biscuit.x + biscuit.width {
             continue;
         }
         let t = (p.life as f32 / PARTICLE_LIFE_F).clamp(0.0, 1.0);
@@ -20,6 +26,6 @@ pub fn draw_particles(frame: &mut Frame, area: Rect, particles: &[Particle]) {
         let style = Style::default()
             .fg(Color::Rgb(255, dim, dim))
             .add_modifier(Modifier::BOLD);
-        buf.set_string(p.col, row, &p.text, style);
+        buf.set_string(col, row, &p.text, style);
     }
 }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -46,8 +46,14 @@ pub enum Mode {
 pub struct DrawOutput {
     pub biscuit_rect: Rect,
     pub golden_rect: Rect,
-    pub visible_upgrades: Vec<usize>,
-    pub visible_fingerers: Vec<usize>,
+    /// `(upgrade_idx, screen_row_rect)` pairs for the Upgrades panel —
+    /// populated only when the active mode renders that panel; empty
+    /// otherwise. The click router hit-tests these for `BuyUpgrade`.
+    /// First element of each tuple is also the digit-shortcut target,
+    /// kept aligned with `visible_upgrades`.
+    pub upgrade_rows: Vec<(usize, Rect)>,
+    /// `(fingerer_idx, screen_row_rect)` for the Game-mode sidebar.
+    pub fingerer_rows: Vec<(usize, Rect)>,
 }
 
 fn wrapped_height(text: &str, width: u16) -> u16 {
@@ -177,7 +183,7 @@ pub fn draw(
 
     let biscuit_rect = biscuit::draw(frame, left[1], state.clench_ticks > 0, zoom_idx);
     hands::draw(frame, left[1], biscuit_rect, state);
-    effects::draw_particles(frame, left[1], &state.particles);
+    effects::draw_particles(frame, biscuit_rect, &state.particles);
     draw_zoom_indicator(
         frame,
         left[1],
@@ -188,7 +194,7 @@ pub fn draw(
         debug_pane::draw(frame, left[1]);
     }
     let golden_rect = match &state.golden {
-        Some(g) => biscuit::draw_golden(frame, g),
+        Some(g) => biscuit::draw_golden(frame, g, biscuit_rect),
         None => Rect::default(),
     };
 
@@ -197,20 +203,20 @@ pub fn draw(
         .wrap(Wrap { trim: false });
     frame.render_widget(help, left[2]);
 
-    let mut visible_upgrades = Vec::new();
-    let mut visible_fingerers = Vec::new();
+    let mut upgrade_rows: Vec<(usize, Rect)> = Vec::new();
+    let mut fingerer_rows: Vec<(usize, Rect)> = Vec::new();
     match mode {
-        Mode::Game => visible_fingerers = sidebar::draw(frame, cols[1], state),
+        Mode::Game => fingerer_rows = sidebar::draw(frame, cols[1], state),
         Mode::Stats => stats::draw(frame, cols[1], state),
         Mode::Achievements => achievements::draw(frame, cols[1], state),
-        Mode::Upgrades => visible_upgrades = upgrades::draw(frame, cols[1], state),
+        Mode::Upgrades => upgrade_rows = upgrades::draw(frame, cols[1], state),
         Mode::Prestige => prestige::draw(frame, cols[1], state),
     }
 
     DrawOutput {
         biscuit_rect,
         golden_rect,
-        visible_upgrades,
-        visible_fingerers,
+        upgrade_rows,
+        fingerer_rows,
     }
 }

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -15,7 +15,11 @@ const FLASH_REST: (f32, f32, f32) = (200.0, 200.0, 210.0);
 const FLASH_CARRIER: (f32, f32, f32) = (255.0, 255.0, 255.0);
 const FLASH_CYCLE: f32 = 11.0;
 
-pub fn draw(frame: &mut Frame, area: Rect, state: &GameState) -> Vec<usize> {
+/// Returns one entry per visible fingerer row: the live `FINGERERS` index
+/// and the click-target rect on screen. Aligned 1:1 with the rendered rows
+/// so the click router can map a click coordinate to an
+/// `Action::BuyFingerer` without re-parsing the panel layout.
+pub fn draw(frame: &mut Frame, area: Rect, state: &GameState) -> Vec<(usize, Rect)> {
     let lang = t();
     let mut lines: Vec<Line> = Vec::new();
     let visible: Vec<usize> = (0..FINGERERS.len())
@@ -76,7 +80,35 @@ pub fn draw(frame: &mut Frame, area: Rect, state: &GameState) -> Vec<usize> {
 
     paint_flashes(frame, area, state, &visible);
 
-    visible
+    if area.width < 3 || area.height < 3 {
+        return Vec::new();
+    }
+    let inner_x = area.x + 1;
+    let inner_y = area.y + 1;
+    let inner_w = area.width.saturating_sub(2);
+    let inner_h = area.height.saturating_sub(2);
+    let mut rows: Vec<(usize, Rect)> = Vec::new();
+    for (slot, &i) in visible.iter().enumerate() {
+        if slot >= 10 {
+            break;
+        }
+        let row_top = slot as u16 * ROWS_PER_FINGERER;
+        if row_top >= inner_h {
+            break;
+        }
+        // Skip the trailing blank separator (3 useful rows out of 4).
+        let height = (ROWS_PER_FINGERER - 1).min(inner_h - row_top);
+        rows.push((
+            i,
+            Rect {
+                x: inner_x,
+                y: inner_y + row_top,
+                width: inner_w,
+                height,
+            },
+        ));
+    }
+    rows
 }
 
 fn paint_flashes(frame: &mut Frame, area: Rect, state: &GameState, visible: &[usize]) {

--- a/src/ui/upgrades.rs
+++ b/src/ui/upgrades.rs
@@ -5,7 +5,15 @@ use crate::game::state::GameState;
 use crate::game::upgrade::{self, UPGRADES};
 use crate::i18n::t;
 
-pub fn draw(frame: &mut Frame, area: Rect, state: &GameState) -> Vec<usize> {
+/// Per-row block height: hotkey+name, indented description, indented cost,
+/// blank separator. Used to compute click hit-test rects below.
+const ROWS_PER_UPGRADE: u16 = 4;
+
+/// Returns one entry per visible upgrade row: the live `UPGRADES` index
+/// and the click-target rect on screen. Aligned 1:1 with the rendered
+/// rows, so the click router can map a click coordinate to an
+/// `Action::BuyUpgrade(idx)` without re-parsing the panel layout.
+pub fn draw(frame: &mut Frame, area: Rect, state: &GameState) -> Vec<(usize, Rect)> {
     let lang = t();
     let available = upgrade::available_ids(state);
     let visible: Vec<usize> = available.iter().take(10).copied().collect();
@@ -58,5 +66,36 @@ pub fn draw(frame: &mut Frame, area: Rect, state: &GameState) -> Vec<usize> {
         .wrap(Wrap { trim: false });
     frame.render_widget(p, area);
 
-    visible
+    // Build per-row click rects. Inside the bordered block: x+1 / y+1 origin,
+    // -2 width / -2 height. Each row block is 3 used lines + 1 blank; clicks
+    // anywhere on those 3 used lines trigger the buy. NB: long descriptions
+    // can wrap, but the headline (hotkey + name + cost block) is always
+    // ROWS_PER_UPGRADE rows in the source `lines`. Using ROWS_PER_UPGRADE-1
+    // (skip the trailing blank) keeps us conservative — clicks on the blank
+    // separator do nothing.
+    if area.width < 3 || area.height < 3 {
+        return Vec::new();
+    }
+    let inner_x = area.x + 1;
+    let inner_y = area.y + 1;
+    let inner_w = area.width.saturating_sub(2);
+    let inner_h = area.height.saturating_sub(2);
+    let mut rows: Vec<(usize, Rect)> = Vec::new();
+    for (slot, &u_idx) in visible.iter().enumerate() {
+        let row_top = slot as u16 * ROWS_PER_UPGRADE;
+        if row_top >= inner_h {
+            break;
+        }
+        let height = (ROWS_PER_UPGRADE - 1).min(inner_h - row_top);
+        rows.push((
+            u_idx,
+            Rect {
+                x: inner_x,
+                y: inner_y + row_top,
+                width: inner_w,
+                height,
+            },
+        ));
+    }
+    rows
 }


### PR DESCRIPTION
## Summary

Closes 5 open issues + 2 follow-up tweaks the user requested while testing. They share enough surface area (DrawOutput shape, click router, golden/particle positioning) that they're cleaner together than as separate PRs.

## What's fixed

- **#6 — Goldens & particles don't track biscuit on zoom/resize.** Switched to fractional anchors (`frac_x, frac_y ∈ [0,1]` within the biscuit). Renderer resolves to absolute every frame against the current `biscuit_rect`. Spawn sites and click coords convert via new `screen_to_biscuit_frac` / `biscuit_frac_to_screen` helpers. Particle rise is a per-tick fraction of biscuit height, calibrated to `0.006` so a `+1` covers ~10-12% of the biscuit over its 1s life — matching the pre-refactor feel.
- **#7 — Golden un-clickable from non-Game panels.** Hoisted the golden hit-test above the mode-gate in `handle_click`. Matches keyboard `g` behavior.
- **#8 + #9 — No mouse-buy in Upgrades panel / sidebar.** Each panel's `draw` fn now returns `Vec<(idx, Rect)>` for click hit-testing, surfaced through `DrawOutput::{upgrade_rows, fingerer_rows}`. Modifier-aware (Shift = ×10, Alt/Ctrl = max).
- **#10 — `build_demo_state` hardcoded catalog ids.** Replaced with index-driven derivation: `DEMO_FINGERER_COUNTS` array applied per slot via `FINGERERS.iter().enumerate()`, then `UPGRADES.iter().take(10)` and `ACHIEVEMENTS.iter().take(6)`. Catalog renames/reorders flow through automatically.
- **Bonus: ass clickable from any panel.** Hoisted biscuit hit-test above mode-specific panel-row routing. Mouse-clicking the cuque from inside Upgrades / Stats / Achievements / Prestige now fingers it.
- **Bonus: keybind cleanup.** `Space` now ALWAYS fingers (every mode, including Prestige). `Enter` is reserved (no-op) for future menu/dialog "accept" use without overloading. `[r]` is the sole prestige confirm. Help text + i18n strings updated EN+pt_BR.

## Tests

- `frac_screen_roundtrip_at_corners`
- `frac_position_survives_biscuit_move`
- `zero_size_biscuit_doesnt_panic`

Plus 3 prior migrate/roundtrip tests. **Total 6 tests, all green.** `cargo fmt --check` ✓ `cargo clippy --all-targets -- -D warnings` ✓.

## Verification

**Visual (`tu` PNG screenshots, keyboard-driven):**
- ✅ Lucky `$` and Frenzy `!` markers track the biscuit through zoom 100% → 70% → 45% → 25%.
- ✅ Golden marker keeps rendering in non-Game panels; keyboard `g` catches it.
- ✅ Demo mode renders 8-tier hands ramp + 10 upgrades + 6 achievements via the new derived seeding.
- ✅ Prestige panel help bar and confirm hint show only `[r]`, no `[Enter]`. Space in Prestige fingers, Enter no-ops.

**Mouse (`tu` v1.0.0 mouse support — every interaction tested end-to-end):**
- ✅ Click biscuit → finger registered, `Cuques` counter ticks up.
- ✅ Click fingerer row in sidebar → buy 1; `Shift+click` → buy 10; `Alt+click` → buy max.
- ✅ Click upgrade row in Upgrades panel → upgrade purchased; cuques debited; row removed from list.
- ✅ Click biscuit while Upgrades panel open → finger registered (ass-clickable-anywhere).
- ✅ Click Lucky `$` marker while Upgrades panel open → caught; cuques credited.
- ✅ Spawn Frenzy `[!]` via F2, mouse-click marker centerpoint → buff applied (HUD shows `[!! FRENZY x777 13s]`); subsequent biscuit click yields `+777` cuques (multiplier verified).
- ✅ Multi-click (`tu mouse click N --clicks 5`), scroll-wheel zoom (`tu mouse scroll up/down`), modifier flags all behave.

The whole click → state mutation → render loop is automatable in CI now — companion `tu` issue ([flipbit03/terminal-use#15](https://github.com/flipbit03/terminal-use/issues/15)) was implemented and shipped as v1.0.0.