### PR TITLE
fix(wasm): unify InputContext construction; add wasm CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,3 +113,35 @@ jobs:
         run: cargo build --release --target ${{ matrix.target }}
         env:
           RUSTFLAGS: ${{ matrix.rustflags }}
+
+  build-web:
+    name: Build (Web wasm)
+    # Catch wasm-only breakage at PR time, not at deploy time. Native and
+    # wasm code paths are gated by `cfg(target_arch = "wasm32")`, so a
+    # missing field on a struct used by `wasm_app.rs` compiles fine on
+    # every native target and only blows up here. (See InputContext +
+    # DrawOutput projection in `crate::input` for why most platform-side
+    # rect plumbing is now centralized.)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Cache cargo registry & build
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: wasm32-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: wasm32-cargo-
+
+      # `cargo check` is enough — the deploy-web workflow does the full
+      # trunk pipeline; here we just want the typecheck to fail fast.
+      - name: Check wasm build
+        run: cargo check --target wasm32-unknown-unknown --release

--- a/src/app.rs
+++ b/src/app.rs
@@ -126,18 +126,11 @@ impl App {
         };
 
         let mut ui = UiState::new();
-        let mut upgrade_rows: Vec<(usize, Rect)> = Vec::new();
-        let mut fingerer_rows: Vec<(usize, Rect)> = Vec::new();
-        let mut biscuit_rect = Rect::default();
-        let mut golden_rect = Rect::default();
-        let mut green_coin_rect = Rect::default();
-        let mut play_area = Rect::default();
-        // M1+M2: help-bar hint click rects + prestige-reset confirm rect.
-        // Both are recomputed every frame and consumed by the click router
-        // so the mouse-first player has equivalents for `[u]`, `[p]`,
-        // `[s]`, `[a]`, `[g]`, `[q]`, and the `[r] reset` confirm.
-        let mut help_hits: Vec<(crate::ui::HelpAction, Rect)> = Vec::new();
-        let mut prestige_reset_rect = Rect::default();
+        // Single per-frame layout snapshot — the source of truth for every
+        // clickable region. The input router consumes it via
+        // `InputContext::from_layout`. Adding a new rect/list goes through
+        // `DrawOutput` + the projection, never here.
+        let mut layout: ui::DrawOutput = Default::default();
         // Reused per-event scratch buffer — `process_input_event` appends
         // produced actions here, then we drain it into the mpsc channel.
         let mut actions: Vec<Action> = Vec::with_capacity(4);
@@ -154,36 +147,17 @@ impl App {
 
             let current = snapshot.load_full();
             terminal.draw(|f| {
-                let out = ui::draw(f, &current, ui.mode, ui.zoom_idx, debug, ui.last_mouse_pos);
-                biscuit_rect = out.biscuit_rect;
-                golden_rect = out.golden_rect;
-                green_coin_rect = out.green_coin_rect;
-                play_area = out.play_area;
-                upgrade_rows = out.upgrade_rows;
-                fingerer_rows = out.fingerer_rows;
-                help_hits = out.help_hits;
-                prestige_reset_rect = out.prestige_reset_rect;
+                layout = ui::draw(f, &current, ui.mode, ui.zoom_idx, debug, ui.last_mouse_pos);
             })?;
 
             // Hand fresh geometry to the sim. Ordering is preserved by mpsc,
             // so the sim always uses the most recently drawn layout.
             let _ = action_tx.send(Action::UpdateGeometry {
-                biscuit: biscuit_rect,
+                biscuit: layout.biscuit_rect,
             });
 
             if event::poll(Duration::from_millis(INPUT_POLL_MS))? {
-                let ctx = InputContext {
-                    fingerer_rows: &fingerer_rows,
-                    upgrade_rows: &upgrade_rows,
-                    help_hits: &help_hits,
-                    biscuit_rect,
-                    golden_rect,
-                    green_coin_rect,
-                    play_area,
-                    prestige_reset_rect,
-                    debug,
-                    current: &current,
-                };
+                let ctx = InputContext::from_layout(&layout, &current, debug);
                 loop {
                     let ev = event::read()?;
                     if let Some(input_ev) = translate_crossterm(ev) {

--- a/src/input.rs
+++ b/src/input.rs
@@ -127,6 +127,36 @@ pub struct InputContext<'a> {
     pub current: &'a GameState,
 }
 
+impl<'a> InputContext<'a> {
+    /// Build an input context by borrowing from a render
+    /// [`DrawOutput`](crate::ui::DrawOutput).
+    ///
+    /// The platform shells (`app.rs`, `wasm_app.rs`) call this so adding
+    /// a new clickable region only touches `DrawOutput` + `InputContext` +
+    /// this projection — never the platform code. Without this single
+    /// projection point, native and wasm each kept their own field-by-field
+    /// copy of the layout snapshot, and a new field meant updating both;
+    /// the wasm build broke once when only the native copy was updated.
+    pub fn from_layout(
+        layout: &'a crate::ui::DrawOutput,
+        current: &'a GameState,
+        debug: bool,
+    ) -> Self {
+        InputContext {
+            fingerer_rows: &layout.fingerer_rows,
+            upgrade_rows: &layout.upgrade_rows,
+            help_hits: &layout.help_hits,
+            biscuit_rect: layout.biscuit_rect,
+            golden_rect: layout.golden_rect,
+            green_coin_rect: layout.green_coin_rect,
+            play_area: layout.play_area,
+            prestige_reset_rect: layout.prestige_reset_rect,
+            debug,
+            current,
+        }
+    }
+}
+
 /// Process one [`InputEvent`]. Mutates [`UiState`]; appends produced actions
 /// to `out`. Pure data — does no I/O. The router *reads* `GameState` (via
 /// `ctx.current` for `prestige_available()` / `golden.is_some()` and via

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -59,6 +59,17 @@ pub enum HelpAction {
     Quit,
 }
 
+/// Per-frame layout snapshot produced by [`draw`]. Single source of truth
+/// for every clickable region on screen + the play-area envelope.
+///
+/// The platform shells (`app.rs`, `wasm_app.rs`) **store this verbatim**
+/// and call [`crate::input::InputContext::from_layout`] to project it
+/// into the per-event input context. Adding a new clickable region only
+/// touches this struct + `InputContext` + the projection — never the
+/// platform code. (We were burned by the alternative once: a missing
+/// `green_coin_rect` field on the wasm-side `InputContext` constructor
+/// crashed the wasm build after the native code shipped just fine.)
+#[derive(Default)]
 pub struct DrawOutput {
     pub biscuit_rect: Rect,
     pub golden_rect: Rect,

--- a/src/wasm_app.rs
+++ b/src/wasm_app.rs
@@ -32,7 +32,6 @@ use std::cell::RefCell;
 use std::rc::Rc;
 
 use ratatui::Terminal;
-use ratatui::layout::Rect;
 use ratzilla::backend::webgl2::{FontAtlasData, WebGl2BackendOptions};
 use ratzilla::event::{
     KeyCode as RzKeyCode, KeyEvent as RzKeyEvent, MouseButton as RzMouseButton,
@@ -47,7 +46,7 @@ use crate::input::{
 };
 use crate::platform::Persistence;
 use crate::sim::{self, Action, SimGeometry};
-use crate::ui::{self, HelpAction};
+use crate::ui;
 
 /// 20Hz sim tick → 50ms per tick.
 const SIM_TICK_MS: f64 = 1000.0 / TICK_HZ as f64;
@@ -70,13 +69,12 @@ const SAVE_INTERVAL_TICKS: u64 = TICK_HZ as u64;
 /// overlap because JS callbacks aren't reentrant within a single task.
 struct WebUi {
     ui: UiState,
-    biscuit_rect: Rect,
-    golden_rect: Rect,
-    play_area: Rect,
-    prestige_reset_rect: Rect,
-    fingerer_rows: Vec<(usize, Rect)>,
-    upgrade_rows: Vec<(usize, Rect)>,
-    help_hits: Vec<(HelpAction, Rect)>,
+    /// Single per-frame layout snapshot — same role as the native
+    /// `App::layout`. `InputContext::from_layout` projects this into the
+    /// per-event input ctx, so adding a new clickable region is one struct
+    /// edit (in `DrawOutput`) and one projection edit (in `InputContext`)
+    /// — no platform-side mirror to keep in sync.
+    layout: crate::ui::DrawOutput,
     /// Wall-clock anchor for sim catch-up. Set on first rAF, advanced
     /// by `SIM_TICK_MS` per tick we actually run.
     last_tick_ms: f64,
@@ -93,13 +91,7 @@ impl WebUi {
     fn new() -> Self {
         Self {
             ui: UiState::new(),
-            biscuit_rect: Rect::default(),
-            golden_rect: Rect::default(),
-            play_area: Rect::default(),
-            prestige_reset_rect: Rect::default(),
-            fingerer_rows: Vec::new(),
-            upgrade_rows: Vec::new(),
-            help_hits: Vec::new(),
+            layout: Default::default(),
             last_tick_ms: now_ms(),
             ticks_since_save: 0,
             cell_pixel_w: 0.0,
@@ -272,7 +264,7 @@ pub fn run() -> Result<(), JsValue> {
         // off and the debug pane / F-key cheats vanish exactly like a
         // shipped native binary.
         let debug = crate::build_info::is_dev_build();
-        let out = ui::draw(
+        web.layout = ui::draw(
             f,
             &state,
             web.ui.mode,
@@ -280,16 +272,9 @@ pub fn run() -> Result<(), JsValue> {
             debug,
             web.ui.last_mouse_pos,
         );
-        web.biscuit_rect = out.biscuit_rect;
-        web.golden_rect = out.golden_rect;
-        web.play_area = out.play_area;
-        web.prestige_reset_rect = out.prestige_reset_rect;
-        web.fingerer_rows = out.fingerer_rows;
-        web.upgrade_rows = out.upgrade_rows;
-        web.help_hits = out.help_hits;
         // Hand the latest biscuit rect to the sim so goldens and auto-
         // particles spawn inside the current layout.
-        geom.biscuit = out.biscuit_rect;
+        geom.biscuit = web.layout.biscuit_rect;
 
         // Re-derive the cell pitch from canvas size vs grid cells.
         //
@@ -349,36 +334,11 @@ fn dispatch(
     let mut actions = actions.borrow_mut();
 
     // Split-borrow `web` so `process_input_event` gets `&mut ui` while
-    // `InputContext` reads the geometry slices/rects from the same struct.
+    // `InputContext::from_layout` reads `&layout` from the same struct.
     // Rust's disjoint-field rule allows this only via explicit
-    // destructuring; the equivalent `&mut web.ui` + `&web.fingerer_rows`
-    // through a `RefMut` deref triggers an aliasing borrow check error.
-    let WebUi {
-        ui,
-        fingerer_rows,
-        upgrade_rows,
-        help_hits,
-        biscuit_rect,
-        golden_rect,
-        play_area,
-        prestige_reset_rect,
-        ..
-    } = &mut *web_ref;
-
-    let ctx = InputContext {
-        fingerer_rows: fingerer_rows.as_slice(),
-        upgrade_rows: upgrade_rows.as_slice(),
-        help_hits: help_hits.as_slice(),
-        biscuit_rect: *biscuit_rect,
-        golden_rect: *golden_rect,
-        play_area: *play_area,
-        prestige_reset_rect: *prestige_reset_rect,
-        // Same gate as `ui::draw` above — release-tagged Pages builds
-        // (Cargo.toml version sed-patched off `0.0.0`) flip this off
-        // and the F-key cheats stop dispatching.
-        debug: crate::build_info::is_dev_build(),
-        current: &state,
-    };
+    // destructuring.
+    let WebUi { ui, layout, .. } = &mut *web_ref;
+    let ctx = InputContext::from_layout(layout, &state, crate::build_info::is_dev_build());
     actions.clear();
     input::process_input_event(ev, ui, &ctx, &mut actions);
     for a in actions.drain(..) {


### PR DESCRIPTION
The wasm deploy broke after #22 because `green_coin_rect` was added to `InputContext` but only the native construction site (`app.rs`) was updated — `wasm_app.rs` kept its own parallel rect mirror that fell out of sync. Native + macOS + Windows + linux-musl all compiled fine; the breakage only surfaced when `deploy-web.yml` ran trunk against the wasm target.

## Root-cause fix, not a patch

Both platforms used to mirror eight render-layout fields (`biscuit_rect`, `golden_rect`, `green_coin_rect`, `play_area`, `prestige_reset_rect`, `fingerer_rows`, `upgrade_rows`, `help_hits`) and reconstruct an `InputContext` literal per event. 8 fields × 2 platforms × 3 sites (own, copy, project) is too much surface for one to drift.

Collapsed: each platform now stores a single `layout: ui::DrawOutput` and calls `InputContext::from_layout(&layout, &state, debug)` — a new constructor that owns the projection. Adding a new clickable region from now on touches `DrawOutput` + `InputContext` + the projection function. Platform shells inherit the change for free.

## What changed

- `src/ui/mod.rs` — `#[derive(Default)]` on `DrawOutput`.
- `src/input.rs` — `InputContext::from_layout(layout, current, debug)` constructor.
- `src/app.rs` — 8 locals → 1 `layout: DrawOutput`; `InputContext` literal → `InputContext::from_layout(...)`.
- `src/wasm_app.rs` — same collapse on `WebUi`. Drops two now-unused imports.
- `.github/workflows/ci.yml` — new `build-web` job runs `cargo check --target wasm32-unknown-unknown --release` on every push + PR.

## Test plan

- [ ] CI: existing native/macOS/Windows/musl matrix passes.
- [ ] CI: new `Build (Web wasm)` job passes — replicates locally with `cargo check --target wasm32-unknown-unknown`.
- [ ] Local: `cargo fmt --check && cargo clippy --all-targets -- -D warnings && cargo test` (87 passing).
- [ ] Local: full `tu`-driven playtest against the rebuilt native release binary covers click economy / multi-tier buys / each powerup variant catch / save-load round-trip / prestige reset.