### PR TITLE
Visual polish + per-variant powerup slots: biscuit symmetry, hands focal-orbit, gold catch flash, independent spawn clocks

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -284,30 +284,48 @@ fn demo_driver_tick(
     }
 
     // Keep the screen busy with goldens: tighter cooldown than normal.
-    if state.golden.is_none() && state.golden_cooldown == 0 {
+    let any_golden = state.goldens.iter().any(|g| g.is_some());
+    if !any_golden && state.golden_cooldown == 0 {
         state.golden_cooldown = DEMO_GOLDEN_COOLDOWN;
     }
 
     // Force the variant on freshly-spawned goldens so the clip deterministically
     // cycles Buff → Frenzy → Lucky. Buff comes first so a viewer definitely
-    // sees the purple powerup.
-    if let Some(g) = &mut state.golden
-        && g.life_ticks == golden::GOLDEN_LIFE_TICKS
-    {
-        g.variant = match *demo_golden_spawns % 3 {
-            0 => GoldenVariant::Buff,
-            1 => GoldenVariant::Frenzy,
-            _ => GoldenVariant::Lucky,
-        };
-        *demo_golden_spawns += 1;
+    // sees the purple powerup. After spawn we MOVE the slot to the
+    // chosen variant's index so the rest of the game's per-variant
+    // routing keeps working.
+    for slot_idx in 0..state.goldens.len() {
+        if let Some(g) = state.goldens[slot_idx].as_ref()
+            && g.life_ticks == golden::GOLDEN_LIFE_TICKS
+        {
+            let target = match *demo_golden_spawns % 3 {
+                0 => GoldenVariant::Buff,
+                1 => GoldenVariant::Frenzy,
+                _ => GoldenVariant::Lucky,
+            };
+            *demo_golden_spawns += 1;
+            if slot_idx != target as usize {
+                let mut g = state.goldens[slot_idx].take().unwrap();
+                g.variant = target;
+                state.goldens[target as usize] = Some(g);
+            } else if let Some(g) = state.goldens[slot_idx].as_mut() {
+                g.variant = target;
+            }
+            break;
+        }
     }
 
-    // Auto-catch whatever golden is on screen after a brief "reaction
-    // time" so the marker is actually visible before disappearing.
-    if let Some(g) = &state.golden
-        && g.life_ticks + 20 < golden::GOLDEN_LIFE_TICKS
-    {
-        state.catch_golden();
+    // Auto-catch whatever golden has been on screen long enough so the
+    // marker is actually visible before disappearing. Iterate every
+    // variant slot independently.
+    for variant in GoldenVariant::ALL {
+        let alive = state.goldens[variant as usize]
+            .as_ref()
+            .map(|g| g.life_ticks + 20 < golden::GOLDEN_LIFE_TICKS)
+            .unwrap_or(false);
+        if alive {
+            state.catch_golden(variant);
+        }
     }
 
     // Every ~4s, buy 1-2 of a random affordable fingerer.

--- a/src/app.rs
+++ b/src/app.rs
@@ -284,9 +284,15 @@ fn demo_driver_tick(
     }
 
     // Keep the screen busy with goldens: tighter cooldown than normal.
+    // Force the next-eligible variant slot's cooldown to a short value
+    // so the demo doesn't have to wait the natural per-variant rng.
     let any_golden = state.goldens.iter().any(|g| g.is_some());
-    if !any_golden && state.golden_cooldown == 0 {
-        state.golden_cooldown = DEMO_GOLDEN_COOLDOWN;
+    if !any_golden {
+        for cd in state.golden_cooldowns.iter_mut() {
+            if *cd == 0 {
+                *cd = DEMO_GOLDEN_COOLDOWN;
+            }
+        }
     }
 
     // Force the variant on freshly-spawned goldens so the clip deterministically
@@ -475,10 +481,11 @@ pub fn build_demo_state() -> GameState {
         total_play_ticks: 3600 * TICK_HZ as u64, // pretend we've been at this an hour
         prestige: 3,
         golden_caught: 7,
-        // Default is a random 20-80s wait; force 0 so the first demo golden
-        // (a Buff, per the cycle in demo_driver_tick) spawns on tick 1 —
-        // the purple powerup lands well within the first few seconds of the clip.
-        golden_cooldown: 0,
+        // Default is a random 20-80s wait per slot; force all to 0 so the
+        // first demo golden (a Buff, per the cycle in demo_driver_tick)
+        // spawns on tick 1 — the purple powerup lands well within the
+        // first few seconds of the clip.
+        golden_cooldowns: [0; 3],
         best_fps: 50_000.0,
         ..GameState::default()
     };

--- a/src/game/golden.rs
+++ b/src/game/golden.rs
@@ -17,6 +17,11 @@ pub enum GoldenVariant {
 }
 
 impl GoldenVariant {
+    /// All variants, in stable discriminant order. `GoldenVariant as usize`
+    /// indexes into `state.goldens` — keep the order in sync with that
+    /// array's slot semantics.
+    pub const ALL: [Self; 3] = [Self::Lucky, Self::Frenzy, Self::Buff];
+
     pub fn random() -> Self {
         let r: f64 = rand::rng().random();
         if r < 0.6 {

--- a/src/game/state.rs
+++ b/src/game/state.rs
@@ -348,10 +348,10 @@ pub struct GameState {
     #[serde(skip)]
     pub upgrade_unlock_flash: Vec<u32>,
     /// Brief gold shimmer on a fingerer row when a Green Coin catch
-    /// targeted it. Closes the visual loop with the floating "+10%
-    /// <fingerer>" particle and the green-tinted title-border pulse —
-    /// the gold here matches the catch particle, so the player can see
-    /// at a glance which row in the sidebar just took the boost.
+    /// targeted it. Closes the visual loop with the floating
+    /// `+10% {fingerer}` particle and the green-tinted title-border
+    /// pulse — the gold here matches the catch particle, so the player
+    /// can see at a glance which row in the sidebar just took the boost.
     #[serde(skip)]
     pub fingerer_green_coin_flash: Vec<u32>,
     /// Previous-tick affordability per row, used to detect the
@@ -412,7 +412,7 @@ pub const PURCHASE_FLASH_TICKS: u32 = 20; // 1s at 20Hz
 pub const GREEN_COIN_FLASH_TICKS: u32 = 50; // 2.5s at 20Hz
 /// Per-row gold shimmer on the targeted fingerer's sidebar row when a
 /// Green Coin catch lands on it. ~2 seconds — long enough for the eye
-/// to track from the floating "+10% <fingerer>" particle over to the
+/// to track from the floating `+10% {fingerer}` particle over to the
 /// row, short enough that it doesn't outlive the catch event.
 pub const GREEN_COIN_ROW_FLASH_TICKS: u32 = TICK_HZ * 2; // 2.0s at 20Hz
 

--- a/src/game/state.rs
+++ b/src/game/state.rs
@@ -258,14 +258,19 @@ pub struct GameState {
     pub misclick_particles: Vec<MisclickParticle>,
     /// Per-variant Golden Cuque slots — `goldens[GoldenVariant::Lucky as usize]`
     /// holds the on-screen Lucky, etc. Each variant has its own independent
-    /// slot so spawning / catching one never clobbers another. The shared
-    /// `golden_cooldown` still throttles the natural spawn rate (one
-    /// roll per cooldown period); the cooldown picks a variant and spawns
-    /// it into its slot only if that slot is empty.
+    /// slot AND its own independent cooldown so spawn timing is fully
+    /// desynchronized — Lucky's clock doesn't gate Frenzy's, and a Buff
+    /// expiring doesn't reset Lucky's cooldown.
     #[serde(skip)]
     pub goldens: [Option<GoldenCuque>; 3],
+    /// Per-variant spawn cooldowns, indexed the same as `goldens`. Each
+    /// freezes while its own slot is occupied (no point counting down
+    /// when there's nowhere to spawn) and rolls a fresh value on
+    /// catch/expiry. Initial values come from `next_cooldown()` in
+    /// `Default`, which already randomizes them so no two variants
+    /// arrive at zero simultaneously on a fresh save.
     #[serde(skip)]
-    pub golden_cooldown: u32,
+    pub golden_cooldowns: [u32; 3],
     /// On-screen Green Coin, if one is currently visible. Lifetime ticked
     /// down by `tick_green_coin`; cleared on catch or expiry. Not persisted
     /// (parallel to `golden`) — closing and reopening the game shouldn't
@@ -443,7 +448,11 @@ impl Default for GameState {
             particles: Vec::new(),
             misclick_particles: Vec::new(),
             goldens: [None, None, None],
-            golden_cooldown: crate::game::golden::next_cooldown(),
+            golden_cooldowns: [
+                crate::game::golden::next_cooldown(),
+                crate::game::golden::next_cooldown(),
+                crate::game::golden::next_cooldown(),
+            ],
             green_coin: None,
             session_ticks: 0,
             newly_unlocked: Vec::new(),
@@ -531,8 +540,13 @@ impl GameState {
                 })
                 .collect();
         }
-        if self.golden_cooldown == 0 {
-            self.golden_cooldown = crate::game::golden::next_cooldown();
+        // Re-seed any cooldown left at 0 by an old save shape (the array
+        // is `#[serde(skip)]` so it's already at default; this is a
+        // defensive guard).
+        for cd in self.golden_cooldowns.iter_mut() {
+            if *cd == 0 {
+                *cd = crate::game::golden::next_cooldown();
+            }
         }
         // Seed the count-up tween at the live values so a freshly-loaded save
         // doesn't animate the HUD "from 0" up to whatever the player had.
@@ -819,7 +833,9 @@ impl GameState {
             return 0.0;
         };
         self.golden_caught += 1;
-        self.golden_cooldown = crate::game::golden::next_cooldown();
+        // Reset only THIS variant's cooldown — sibling variants keep their
+        // own clocks running on independent schedules.
+        self.golden_cooldowns[variant as usize] = crate::game::golden::next_cooldown();
         let (reward, label) = match golden.variant {
             GoldenVariant::Lucky => {
                 self.lucky_caught += 1;
@@ -964,7 +980,11 @@ impl GameState {
         // Pity counter resets too — the new run earns its own Green Coins.
         self.goldens_since_green_coin = 0;
         self.clench_ticks = 0;
-        self.golden_cooldown = crate::game::golden::next_cooldown();
+        // Fresh per-variant cooldowns so the new run has its own
+        // independent rhythm from tick 1.
+        for cd in self.golden_cooldowns.iter_mut() {
+            *cd = crate::game::golden::next_cooldown();
+        }
         true
     }
 
@@ -1170,26 +1190,21 @@ impl GameState {
     }
 
     pub fn tick_golden(&mut self) {
-        // Each variant ages independently. The shared cooldown ticks down
-        // only when EVERY slot is empty — the player isn't punished by a
-        // cooldown reset just because one variant happens to be on screen.
-        let mut any_alive = false;
-        let mut any_just_expired = false;
-        for slot in self.goldens.iter_mut() {
-            if let Some(g) = slot.as_mut() {
+        // Each variant ages on its own clock. Lifetime ticks down per
+        // slot; on expiry, that slot's cooldown rolls fresh. Cooldown
+        // ticks down only when its variant's slot is empty — no point
+        // counting down to zero while there's nowhere to spawn.
+        for i in 0..self.goldens.len() {
+            if let Some(g) = self.goldens[i].as_mut() {
                 if g.life_ticks == 0 {
-                    *slot = None;
-                    any_just_expired = true;
+                    self.goldens[i] = None;
+                    self.golden_cooldowns[i] = crate::game::golden::next_cooldown();
                 } else {
                     g.life_ticks -= 1;
-                    any_alive = true;
                 }
+            } else if self.golden_cooldowns[i] > 0 {
+                self.golden_cooldowns[i] -= 1;
             }
-        }
-        if any_just_expired {
-            self.golden_cooldown = crate::game::golden::next_cooldown();
-        } else if !any_alive && self.golden_cooldown > 0 {
-            self.golden_cooldown -= 1;
         }
     }
 

--- a/src/game/state.rs
+++ b/src/game/state.rs
@@ -256,8 +256,14 @@ pub struct GameState {
     /// MISSED the biscuit, including the dead zone at low zoom).
     #[serde(skip)]
     pub misclick_particles: Vec<MisclickParticle>,
+    /// Per-variant Golden Cuque slots — `goldens[GoldenVariant::Lucky as usize]`
+    /// holds the on-screen Lucky, etc. Each variant has its own independent
+    /// slot so spawning / catching one never clobbers another. The shared
+    /// `golden_cooldown` still throttles the natural spawn rate (one
+    /// roll per cooldown period); the cooldown picks a variant and spawns
+    /// it into its slot only if that slot is empty.
     #[serde(skip)]
-    pub golden: Option<GoldenCuque>,
+    pub goldens: [Option<GoldenCuque>; 3],
     #[serde(skip)]
     pub golden_cooldown: u32,
     /// On-screen Green Coin, if one is currently visible. Lifetime ticked
@@ -436,7 +442,7 @@ impl Default for GameState {
             clench_ticks: 0,
             particles: Vec::new(),
             misclick_particles: Vec::new(),
-            golden: None,
+            goldens: [None, None, None],
             golden_cooldown: crate::game::golden::next_cooldown(),
             green_coin: None,
             session_ticks: 0,
@@ -794,18 +800,22 @@ impl GameState {
         self.cuques_flash_ticks = HUD_FLASH_TICKS;
     }
 
-    /// Catch whatever Golden Cuque is currently on screen (any variant:
-    /// Lucky, Frenzy, or Buff). Applies the variant-specific effect,
-    /// increments `golden_caught`, re-rolls the next spawn cooldown, and
-    /// returns the flat reward (0.0 for buff variants).
+    /// Catch the Golden Cuque of the given variant if one is currently
+    /// on screen. Applies the variant-specific effect, increments
+    /// `golden_caught` + the per-variant counter, re-rolls the shared
+    /// spawn cooldown, and returns the flat reward (0.0 for non-Lucky).
+    ///
+    /// Each variant lives in its own slot of `state.goldens`, so catching
+    /// e.g. a Lucky never disturbs an active Frenzy or Buff. Same applies
+    /// to expiry / cheat spawns.
     ///
     /// The `Buff` variant attaches a `MulFactor(7.0)` modifier with a
     /// 60-second `Ticks` duration on a random owned fingerer, sourced as
     /// `PurpleCoin`. Pre-#21 this was a global `Buff::FingererBoost`; the
     /// modifier system replaces it.
-    pub fn catch_golden(&mut self) -> f64 {
+    pub fn catch_golden(&mut self, variant: crate::game::golden::GoldenVariant) -> f64 {
         use crate::game::golden::GoldenVariant;
-        let Some(golden) = self.golden.take() else {
+        let Some(golden) = self.goldens[variant as usize].take() else {
             return 0.0;
         };
         self.golden_caught += 1;
@@ -949,7 +959,7 @@ impl GameState {
         self.visual_debt = 0.0;
         self.particles.clear();
         self.misclick_particles.clear();
-        self.golden = None;
+        self.goldens = [None, None, None];
         self.green_coin = None;
         // Pity counter resets too — the new run earns its own Green Coins.
         self.goldens_since_green_coin = 0;
@@ -1160,14 +1170,25 @@ impl GameState {
     }
 
     pub fn tick_golden(&mut self) {
-        if let Some(g) = self.golden.as_mut() {
-            if g.life_ticks == 0 {
-                self.golden = None;
-                self.golden_cooldown = crate::game::golden::next_cooldown();
-            } else {
-                g.life_ticks -= 1;
+        // Each variant ages independently. The shared cooldown ticks down
+        // only when EVERY slot is empty — the player isn't punished by a
+        // cooldown reset just because one variant happens to be on screen.
+        let mut any_alive = false;
+        let mut any_just_expired = false;
+        for slot in self.goldens.iter_mut() {
+            if let Some(g) = slot.as_mut() {
+                if g.life_ticks == 0 {
+                    *slot = None;
+                    any_just_expired = true;
+                } else {
+                    g.life_ticks -= 1;
+                    any_alive = true;
+                }
             }
-        } else if self.golden_cooldown > 0 {
+        }
+        if any_just_expired {
+            self.golden_cooldown = crate::game::golden::next_cooldown();
+        } else if !any_alive && self.golden_cooldown > 0 {
             self.golden_cooldown -= 1;
         }
     }

--- a/src/game/state.rs
+++ b/src/game/state.rs
@@ -336,6 +336,13 @@ pub struct GameState {
     pub fingerer_unlock_flash: Vec<u32>,
     #[serde(skip)]
     pub upgrade_unlock_flash: Vec<u32>,
+    /// Brief gold shimmer on a fingerer row when a Green Coin catch
+    /// targeted it. Closes the visual loop with the floating "+10%
+    /// <fingerer>" particle and the green-tinted title-border pulse —
+    /// the gold here matches the catch particle, so the player can see
+    /// at a glance which row in the sidebar just took the boost.
+    #[serde(skip)]
+    pub fingerer_green_coin_flash: Vec<u32>,
     /// Previous-tick affordability per row, used to detect the
     /// false→true edge that triggers `*_unlock_flash`. Sized to catalog
     /// length by `migrate()` and seeded at init from the live state, so a
@@ -392,6 +399,11 @@ pub const PURCHASE_FLASH_TICKS: u32 = 20; // 1s at 20Hz
 /// blip lands without lingering for so long it competes with whatever might
 /// be running on top (Frenzy, Buff, Lucky).
 pub const GREEN_COIN_FLASH_TICKS: u32 = 50; // 2.5s at 20Hz
+/// Per-row gold shimmer on the targeted fingerer's sidebar row when a
+/// Green Coin catch lands on it. ~2 seconds — long enough for the eye
+/// to track from the floating "+10% <fingerer>" particle over to the
+/// row, short enough that it doesn't outlive the catch event.
+pub const GREEN_COIN_ROW_FLASH_TICKS: u32 = TICK_HZ * 2; // 2.0s at 20Hz
 
 /// Serde default for `GameState::version`. A direct deserialize of the live
 /// `GameState` from a pre-versioned save (one without the field) still
@@ -445,6 +457,7 @@ impl Default for GameState {
             upgrade_unaffordable_flash: vec![0; UPGRADES.len()],
             fingerer_unlock_flash: vec![0; fingerer::count()],
             upgrade_unlock_flash: vec![0; UPGRADES.len()],
+            fingerer_green_coin_flash: vec![0; fingerer::count()],
             prev_fingerer_affordable: vec![false; fingerer::count()],
             prev_upgrade_affordable: vec![false; UPGRADES.len()],
             space_pressed_this_tick: false,
@@ -493,6 +506,9 @@ impl GameState {
         }
         if self.upgrade_unlock_flash.len() != UPGRADES.len() {
             self.upgrade_unlock_flash = vec![0; UPGRADES.len()];
+        }
+        if self.fingerer_green_coin_flash.len() != fingerer::count() {
+            self.fingerer_green_coin_flash = vec![0; fingerer::count()];
         }
         // Seed `prev_affordable` from the LIVE state so a freshly-loaded
         // save with rows already affordable doesn't fire spurious unlock
@@ -995,6 +1011,9 @@ impl GameState {
         for t in self.upgrade_unlock_flash.iter_mut() {
             *t = t.saturating_sub(1);
         }
+        for t in self.fingerer_green_coin_flash.iter_mut() {
+            *t = t.saturating_sub(1);
+        }
         // Held-spacebar streak with a small grace window. Real key-repeat
         // is bursty (~30Hz nominal but with OS-level jitter), so a strict
         // "every tick must see a press" test breaks on a single missed
@@ -1202,11 +1221,17 @@ impl GameState {
         self.green_coin_caught += 1;
         self.green_coin_flash_ticks = GREEN_COIN_FLASH_TICKS;
         // Visual feedback: a "+10% <fingerer>" particle anchored at the
-        // coin's position. Phase 5 wraps this with a green border channel
-        // pulse and proper marker rendering.
+        // coin's position + a gold sidebar-row shimmer on the targeted
+        // tier (closes the loop between the floating particle and the
+        // sidebar badge that just gained another +10%).
         let label = match &chosen {
             Some(id) => {
                 let idx = FINGERERS.iter().position(|f| f.id == id);
+                if let Some(i) = idx
+                    && let Some(slot) = self.fingerer_green_coin_flash.get_mut(i)
+                {
+                    *slot = GREEN_COIN_ROW_FLASH_TICKS;
+                }
                 let name = idx
                     .and_then(|i| crate::i18n::t().fingerer_names.get(i).copied())
                     .unwrap_or("?");

--- a/src/input.rs
+++ b/src/input.rs
@@ -116,6 +116,10 @@ pub struct InputContext<'a> {
     pub upgrade_rows: &'a [(usize, Rect)],
     pub help_hits: &'a [(HelpAction, Rect)],
     pub biscuit_rect: Rect,
+    /// Screen position of the biscuit's focal cell. See
+    /// [`crate::ui::DrawOutput::biscuit_focal`]. Used by `hands::occupied_at`
+    /// to keep its hit-test math in sync with the visual orbit.
+    pub biscuit_focal: (u16, u16),
     pub golden_rect: Rect,
     /// Hit-test rect for the on-screen Green Coin marker. Zero-rect when
     /// no coin is visible; click-routes through `Action::CatchGolden` (the
@@ -147,6 +151,7 @@ impl<'a> InputContext<'a> {
             upgrade_rows: &layout.upgrade_rows,
             help_hits: &layout.help_hits,
             biscuit_rect: layout.biscuit_rect,
+            biscuit_focal: layout.biscuit_focal,
             golden_rect: layout.golden_rect,
             green_coin_rect: layout.green_coin_rect,
             play_area: layout.play_area,
@@ -364,7 +369,7 @@ fn handle_click(
     if !rect_contains(ctx.play_area, col, row) {
         return;
     }
-    if crate::ui::hands::occupied_at(col, row, ctx.biscuit_rect, ctx.current) {
+    if crate::ui::hands::occupied_at(col, row, ctx.biscuit_rect, ctx.biscuit_focal, ctx.current) {
         return;
     }
     out.push(Action::Misclick { col, row });
@@ -570,6 +575,7 @@ mod tests {
             upgrade_rows,
             help_hits,
             biscuit_rect: biscuit,
+            biscuit_focal: (0, 0),
             golden_rect,
             green_coin_rect: Rect::default(),
             play_area,

--- a/src/input.rs
+++ b/src/input.rs
@@ -120,10 +120,12 @@ pub struct InputContext<'a> {
     /// [`crate::ui::DrawOutput::biscuit_focal`]. Used by `hands::occupied_at`
     /// to keep its hit-test math in sync with the visual orbit.
     pub biscuit_focal: (u16, u16),
-    pub golden_rect: Rect,
+    /// One rect per Golden variant slot (Lucky/Frenzy/Buff), indexed by
+    /// `GoldenVariant as usize`. Each is hit-tested independently so
+    /// clicking one variant catches only that variant.
+    pub golden_rects: [Rect; 3],
     /// Hit-test rect for the on-screen Green Coin marker. Zero-rect when
-    /// no coin is visible; click-routes through `Action::CatchGolden` (the
-    /// sim resolves both Golden and Green Coin from that single action).
+    /// no coin is visible; click-routes through `Action::CatchGreenCoin`.
     pub green_coin_rect: Rect,
     pub play_area: Rect,
     pub prestige_reset_rect: Rect,
@@ -152,7 +154,7 @@ impl<'a> InputContext<'a> {
             help_hits: &layout.help_hits,
             biscuit_rect: layout.biscuit_rect,
             biscuit_focal: layout.biscuit_focal,
-            golden_rect: layout.golden_rect,
+            golden_rects: layout.golden_rects,
             green_coin_rect: layout.green_coin_rect,
             play_area: layout.play_area,
             prestige_reset_rect: layout.prestige_reset_rect,
@@ -237,6 +239,34 @@ fn rect_contains(rect: Rect, col: u16, row: u16) -> bool {
         && row < rect.y + rect.height
 }
 
+/// Push the catch action for whichever on-screen powerup has the fewest
+/// life ticks remaining (most-urgent across Lucky / Frenzy / Buff /
+/// Green Coin). No-op if nothing is on screen. Shared by the keyboard
+/// `g` handler and the help-bar `[g]` click.
+fn push_grab_most_urgent(ctx: &InputContext, out: &mut Vec<Action>) {
+    use crate::game::golden::GoldenVariant;
+    let mut best: Option<(u32, Action)> = None;
+    for variant in GoldenVariant::ALL {
+        if let Some(g) = ctx.current.goldens[variant as usize].as_ref() {
+            let action = Action::CatchGolden(variant);
+            best = match best {
+                Some((life, _)) if life <= g.life_ticks => best,
+                _ => Some((g.life_ticks, action)),
+            };
+        }
+    }
+    if let Some(c) = ctx.current.green_coin.as_ref() {
+        let action = Action::CatchGreenCoin;
+        best = match best {
+            Some((life, _)) if life <= c.life_ticks => best,
+            _ => Some((c.life_ticks, action)),
+        };
+    }
+    if let Some((_, a)) = best {
+        out.push(a);
+    }
+}
+
 fn click_buy_qty(mods: Modifiers) -> BuyQty {
     if mods.alt || mods.ctrl {
         BuyQty::Max
@@ -280,9 +310,9 @@ fn try_help_click(
                 };
             }
             HelpAction::GrabGolden => {
-                if ctx.current.golden.is_some() {
-                    out.push(Action::CatchGolden);
-                }
+                // Help-bar `[g]` click — grab the most-urgent powerup
+                // currently on screen, identical to the keyboard 'g'.
+                push_grab_most_urgent(ctx, out);
             }
             HelpAction::PrestigeReset => {
                 if ctx.current.prestige_available() > 0 {
@@ -312,8 +342,18 @@ fn handle_click(
     // behavior, which has no mode guard. The marker still renders on the
     // biscuit while a non-Game panel is open. Right-click on a golden
     // also catches.
-    if rect_contains(ctx.golden_rect, col, row) || rect_contains(ctx.green_coin_rect, col, row) {
-        out.push(Action::CatchGolden);
+    // Each powerup marker is its own click target — clicking on the
+    // golden does NOT also vacuum up an adjacent green coin or sibling
+    // golden variant. Lucky/Frenzy/Buff/GreenCoin can all coexist on
+    // screen; each one catches only itself.
+    for variant in crate::game::golden::GoldenVariant::ALL {
+        if rect_contains(ctx.golden_rects[variant as usize], col, row) {
+            out.push(Action::CatchGolden(variant));
+            return;
+        }
+    }
+    if rect_contains(ctx.green_coin_rect, col, row) {
+        out.push(Action::CatchGreenCoin);
         return;
     }
     // Clicking the biscuit itself is also mode-agnostic. Right-click on
@@ -417,12 +457,13 @@ fn handle_key(
                 Mode::Upgrades
             };
         }
-        // [g] catches any Golden Cuque variant. Guard on the latest snapshot
-        // to avoid sending a noop CatchGolden when nothing is on screen.
-        KeyCode::Char('g') | KeyCode::Char('G')
-            if ctx.current.golden.is_some() || ctx.current.green_coin.is_some() =>
-        {
-            out.push(Action::CatchGolden);
+        // [g] catches the most-urgent powerup (lowest remaining life
+        // ticks) across all four slots — Lucky, Frenzy, Buff, and
+        // Green Coin. A second [g] press grabs the next-most-urgent.
+        // Lets the player race against expiry without the keyboard
+        // accidentally vacuuming up siblings.
+        KeyCode::Char('g') | KeyCode::Char('G') => {
+            push_grab_most_urgent(ctx, out);
         }
         // Debug/testing: gated by `debug`. See src/ui/debug_pane.rs for the
         // advertised key list. F8 (not F1) is Lucky because Chrome / Edge /
@@ -570,13 +611,17 @@ mod tests {
         debug: bool,
         current: &'a GameState,
     ) -> InputContext<'a> {
+        // Helper places `golden_rect` in the Lucky slot; tests targeting
+        // a different variant can mutate `golden_rects` after construction.
+        let mut golden_rects = [Rect::default(); 3];
+        golden_rects[GoldenVariant::Lucky as usize] = golden_rect;
         InputContext {
             fingerer_rows,
             upgrade_rows,
             help_hits,
             biscuit_rect: biscuit,
             biscuit_focal: (0, 0),
-            golden_rect,
+            golden_rects,
             green_coin_rect: Rect::default(),
             play_area,
             prestige_reset_rect,
@@ -599,15 +644,14 @@ mod tests {
         )
     }
 
-    /// State with a golden cuque on screen, so [g] / golden-rect clicks have
-    /// something to catch.
+    /// State with a Lucky golden in its dedicated slot, so [g] /
+    /// golden-rect clicks have something to catch.
     fn state_with_golden() -> GameState {
         let mut g = golden::spawn_in(rect(10, 10, 20, 10));
         g.variant = GoldenVariant::Lucky;
-        GameState {
-            golden: Some(g),
-            ..GameState::default()
-        }
+        let mut s = GameState::default();
+        s.goldens[GoldenVariant::Lucky as usize] = Some(g);
+        s
     }
 
     /// State with enough lifetime cuques to make `prestige_available()` > 0,
@@ -715,7 +759,7 @@ mod tests {
         let mut ui = UiState::new();
         let mut out = Vec::new();
         process_input_event(key(KeyCode::Char('g')), &mut ui, &empty_ctx(&s), &mut out);
-        assert!(matches!(out.as_slice(), [Action::CatchGolden]));
+        assert!(matches!(out.as_slice(), [Action::CatchGolden(_)]));
     }
 
     #[test]
@@ -961,7 +1005,79 @@ mod tests {
             &c,
             &mut out,
         );
-        assert!(matches!(out.as_slice(), [Action::CatchGolden]));
+        assert!(matches!(out.as_slice(), [Action::CatchGolden(_)]));
+    }
+
+    #[test]
+    fn left_click_on_green_coin_emits_green_catch_only() {
+        // Regression: clicking the green-coin marker used to emit
+        // `Action::CatchGolden`, which would catch BOTH a Golden and a
+        // Green Coin if both were on screen. They're separate now.
+        let mut s = state_with_golden();
+        s.green_coin = Some(crate::game::green_coin::GreenCoin {
+            frac_x: 0.5,
+            frac_y: 0.5,
+            life_ticks: 100,
+        });
+        let mut ui = UiState::new();
+        let mut c = ctx(
+            Rect::default(),
+            rect(50, 12, 4, 2),
+            rect(0, 0, 100, 30),
+            Rect::default(),
+            &[],
+            &[],
+            &[],
+            false,
+            &s,
+        );
+        c.green_coin_rect = rect(70, 12, 5, 3);
+        let mut out = Vec::new();
+        process_input_event(
+            mouse_down(72, 13, MouseButton::Left, Modifiers::default()),
+            &mut ui,
+            &c,
+            &mut out,
+        );
+        assert!(matches!(out.as_slice(), [Action::CatchGreenCoin]));
+    }
+
+    #[test]
+    fn g_with_both_powerups_picks_lower_life_ticks() {
+        // [g] should grab the most-urgent powerup first when both are on
+        // screen, then a follow-up [g] press grabs the leftover. Tie
+        // (g_life == c_life) goes to the regular Golden as a tiebreak.
+        let mut s = state_with_golden();
+        // Pin life_ticks so we control the ordering.
+        if let Some(g) = s.goldens[GoldenVariant::Lucky as usize].as_mut() {
+            g.life_ticks = 50;
+        }
+        s.green_coin = Some(crate::game::green_coin::GreenCoin {
+            frac_x: 0.5,
+            frac_y: 0.5,
+            life_ticks: 200,
+        });
+        let c = empty_ctx(&s);
+        let mut ui = UiState::new();
+        let mut out = Vec::new();
+        process_input_event(key(KeyCode::Char('g')), &mut ui, &c, &mut out);
+        // Golden has 50 ticks left, green has 200 — Golden is more urgent.
+        assert!(matches!(out.as_slice(), [Action::CatchGolden(_)]));
+
+        // Flip the lifetimes — green is now the urgent one.
+        let mut s = state_with_golden();
+        if let Some(g) = s.goldens[GoldenVariant::Lucky as usize].as_mut() {
+            g.life_ticks = 200;
+        }
+        s.green_coin = Some(crate::game::green_coin::GreenCoin {
+            frac_x: 0.5,
+            frac_y: 0.5,
+            life_ticks: 50,
+        });
+        let c = empty_ctx(&s);
+        let mut out = Vec::new();
+        process_input_event(key(KeyCode::Char('g')), &mut ui, &c, &mut out);
+        assert!(matches!(out.as_slice(), [Action::CatchGreenCoin]));
     }
 
     #[test]
@@ -987,7 +1103,7 @@ mod tests {
             &c,
             &mut out,
         );
-        assert!(matches!(out.as_slice(), [Action::CatchGolden]));
+        assert!(matches!(out.as_slice(), [Action::CatchGolden(_)]));
     }
 
     #[test]

--- a/src/sim.rs
+++ b/src/sim.rs
@@ -43,7 +43,12 @@ pub enum Action {
         row: u16,
     },
     ClickCenter,
-    CatchGolden,
+    /// Catch the Golden Cuque of the given variant. Each variant has its
+    /// own independent on-screen slot, so this only catches the targeted
+    /// one — never vacuums up a neighbor.
+    CatchGolden(GoldenVariant),
+    /// Catch the on-screen Green Coin specifically.
+    CatchGreenCoin,
     BuyFingerer {
         idx: usize,
         qty: BuyQty,
@@ -106,12 +111,10 @@ pub fn apply_action(state: &mut GameState, action: Action, geom: &mut SimGeometr
             // key (terminal repeat) → streak climbs over time.
             state.space_pressed_this_tick = true;
         }
-        Action::CatchGolden => {
-            // Catch button is unified across the on-screen powerups — try
-            // both and let whichever's present consume the press. Order
-            // doesn't matter (independent slots) but Golden goes first to
-            // match the legacy code path.
-            state.catch_golden();
+        Action::CatchGolden(variant) => {
+            state.catch_golden(variant);
+        }
+        Action::CatchGreenCoin => {
             state.catch_green_coin();
         }
         Action::BuyFingerer { idx, qty } => match qty {
@@ -190,13 +193,23 @@ fn maybe_spawn_auto_particle(state: &mut GameState, geom: &SimGeometry) {
 }
 
 fn maybe_spawn_golden(state: &mut GameState, geom: &SimGeometry) {
-    if state.golden.is_some() || state.golden_cooldown > 0 {
+    if state.golden_cooldown > 0 {
         return;
     }
     if geom.biscuit.width < 8 || geom.biscuit.height < 5 {
         return;
     }
-    state.golden = Some(golden::spawn_in(geom.biscuit));
+    // Roll a variant; only spawn if THAT variant's slot is empty. Each
+    // variant has its own independent slot, so a Frenzy on screen doesn't
+    // block a Lucky from spawning. If the rolled slot is already
+    // occupied, skip this attempt — the cooldown re-rolls naturally.
+    let variant = GoldenVariant::random();
+    if state.goldens[variant as usize].is_some() {
+        return;
+    }
+    let mut g = golden::spawn_in(geom.biscuit);
+    g.variant = variant;
+    state.goldens[variant as usize] = Some(g);
 
     // Green Coin spawn pity: each regular Golden spawn bumps the chance
     // by 1%. The roll fires whether or not a Green Coin slot is currently
@@ -218,9 +231,15 @@ fn force_spawn_golden(state: &mut GameState, geom: &SimGeometry, variant: Golden
     if geom.biscuit.width < 8 || geom.biscuit.height < 5 {
         return;
     }
+    // Per-variant slot: F-key cheats only spawn into their own slot —
+    // pressing F2 (Frenzy) never displaces an active Lucky, etc. If
+    // that slot is already occupied, the press is a no-op.
+    if state.goldens[variant as usize].is_some() {
+        return;
+    }
     let mut g = golden::spawn_in(geom.biscuit);
     g.variant = variant;
-    state.golden = Some(g);
+    state.goldens[variant as usize] = Some(g);
 }
 
 fn force_spawn_green_coin(state: &mut GameState, geom: &SimGeometry) {
@@ -231,4 +250,44 @@ fn force_spawn_green_coin(state: &mut GameState, geom: &SimGeometry) {
         return;
     }
     state.green_coin = Some(green_coin::spawn_in(geom.biscuit));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::game::state::GameState;
+    use ratatui::layout::Rect;
+
+    fn geom_with_biscuit() -> SimGeometry {
+        SimGeometry {
+            biscuit: Rect::new(0, 0, 40, 20),
+        }
+    }
+
+    #[test]
+    fn force_spawn_does_not_clobber_other_variants() {
+        // Regression: prior to per-variant slots, pressing F2 (Frenzy)
+        // would replace an existing Lucky on screen. With per-variant
+        // slots, every variant has independent state.
+        let mut state = GameState::default();
+        let geom = geom_with_biscuit();
+        force_spawn_golden(&mut state, &geom, GoldenVariant::Lucky);
+        force_spawn_golden(&mut state, &geom, GoldenVariant::Frenzy);
+        force_spawn_golden(&mut state, &geom, GoldenVariant::Buff);
+        assert!(state.goldens[GoldenVariant::Lucky as usize].is_some());
+        assert!(state.goldens[GoldenVariant::Frenzy as usize].is_some());
+        assert!(state.goldens[GoldenVariant::Buff as usize].is_some());
+    }
+
+    #[test]
+    fn catch_golden_only_consumes_targeted_variant() {
+        let mut state = GameState::default();
+        let geom = geom_with_biscuit();
+        force_spawn_golden(&mut state, &geom, GoldenVariant::Lucky);
+        force_spawn_golden(&mut state, &geom, GoldenVariant::Frenzy);
+        // Catching Lucky leaves Frenzy alone.
+        state.catch_golden(GoldenVariant::Lucky);
+        assert!(state.goldens[GoldenVariant::Lucky as usize].is_none());
+        assert!(state.goldens[GoldenVariant::Frenzy as usize].is_some());
+    }
 }

--- a/src/sim.rs
+++ b/src/sim.rs
@@ -193,36 +193,33 @@ fn maybe_spawn_auto_particle(state: &mut GameState, geom: &SimGeometry) {
 }
 
 fn maybe_spawn_golden(state: &mut GameState, geom: &SimGeometry) {
-    if state.golden_cooldown > 0 {
-        return;
-    }
     if geom.biscuit.width < 8 || geom.biscuit.height < 5 {
         return;
     }
-    // Roll a variant; only spawn if THAT variant's slot is empty. Each
-    // variant has its own independent slot, so a Frenzy on screen doesn't
-    // block a Lucky from spawning. If the rolled slot is already
-    // occupied, skip this attempt — the cooldown re-rolls naturally.
-    let variant = GoldenVariant::random();
-    if state.goldens[variant as usize].is_some() {
-        return;
-    }
-    let mut g = golden::spawn_in(geom.biscuit);
-    g.variant = variant;
-    state.goldens[variant as usize] = Some(g);
+    // Each variant runs on its own clock — find the variants whose
+    // cooldown has hit zero and whose slot is empty, and spawn each.
+    // Cooldown reset for that variant happens here too, so a stuck
+    // zero-cooldown can't re-spawn every tick.
+    for variant in GoldenVariant::ALL {
+        let i = variant as usize;
+        if state.golden_cooldowns[i] > 0 || state.goldens[i].is_some() {
+            continue;
+        }
+        let mut g = golden::spawn_in(geom.biscuit);
+        g.variant = variant;
+        state.goldens[i] = Some(g);
+        state.golden_cooldowns[i] = crate::game::golden::next_cooldown();
 
-    // Green Coin spawn pity: each regular Golden spawn bumps the chance
-    // by 1%. The roll fires whether or not a Green Coin slot is currently
-    // free; if one's already on screen, the counter still increments but
-    // the roll is *not* re-cast (the existing coin keeps its turn). The
-    // counter resets the moment a Green Coin appears, regardless of
-    // whether the player catches it or it expires.
-    state.goldens_since_green_coin = state.goldens_since_green_coin.saturating_add(1);
-    if state.green_coin.is_none() {
-        let p = state.goldens_since_green_coin as f64 * 0.01;
-        if rand::rng().random::<f64>() < p {
-            state.green_coin = Some(green_coin::spawn_in(geom.biscuit));
-            state.goldens_since_green_coin = 0;
+        // Green Coin spawn pity: each regular Golden spawn bumps the
+        // chance by 1%. Counter resets the moment a Green Coin appears,
+        // regardless of whether the player catches it or it expires.
+        state.goldens_since_green_coin = state.goldens_since_green_coin.saturating_add(1);
+        if state.green_coin.is_none() {
+            let p = state.goldens_since_green_coin as f64 * 0.01;
+            if rand::rng().random::<f64>() < p {
+                state.green_coin = Some(green_coin::spawn_in(geom.biscuit));
+                state.goldens_since_green_coin = 0;
+            }
         }
     }
 }

--- a/src/ui/biscuit.rs
+++ b/src/ui/biscuit.rs
@@ -40,16 +40,28 @@ fn prestige_body_tint(prestige: u64) -> ((f32, f32, f32), f32) {
 // `replace('O', '|')` collateral-damaging the `|` walls on rows 9-21,
 // and the burning-pulse overpaint also got fooled into picking the
 // wrong row when searching for a stand-in glyph.
+// Body walls at cols 1 and 59 → visual center column 30. The right-side
+// curve rows (2-8 top, 21-27 bottom) used to extend 1 column further from
+// center than their left-side mirrors, so the right wall `|` sat at the
+// same column as the curve `\` above it (no rounding offset) while the
+// left side had `/` 1 col inside the wall — visibly asymmetric. Shifted
+// the right cluster on each curve row 1 col left so the right contour now
+// rounds into the wall the same way the left does.
+//
+// Rows 0, 1, 28, 29 (the underscore row + adjacent `__,-~~` row) sit at
+// half-column offsets from the body center; their |L|/|R| asymmetry is
+// inherent to the even-width middle gap, and a 1-col shift just flips
+// which side is shorter. Left as-is.
 const BISCUIT_FULL: &[&str] = &[
     r"                    ____________________                    ",
     r"              __,-~~                    ~~-,__              ",
-    r"           ,-~'                                `~-,         ",
-    r"        ,-'                                        `-,      ",
-    r"      ,'                                              `.    ",
-    r"     /         -~-~-~-              -~-~-~-             \   ",
-    r"    /                                                    \  ",
-    r"   /             -~~-~-~~-                                \ ",
-    r"  /                                                        \",
+    r"           ,-~'                               `~-,          ",
+    r"        ,-'                                       `-,       ",
+    r"      ,'                                             `.     ",
+    r"     /         -~-~-~-              -~-~-~-            \    ",
+    r"    /                                                   \   ",
+    r"   /             -~~-~-~~-                               \  ",
+    r"  /                                                       \ ",
     r" |          -~-~-~-~-             -~-~-~-~-                |",
     r" |                                                         |",
     r" |                                                         |",
@@ -62,13 +74,13 @@ const BISCUIT_FULL: &[&str] = &[
     r" |                  ////////   |   \\\\\\\\                |",
     r" |                                                         |",
     r" |          -~-~-~-~-             -~-~-~-~-                |",
-    r"  \                                                        /",
-    r"   \             -~~-~-~~-                                / ",
-    r"    \                                                    /  ",
-    r"     \         -~-~-~-              -~-~-~-             /   ",
-    r"      `.                                              ,'    ",
-    r"        `-,                                        ,-'      ",
-    r"           `~-,                                ,-~'         ",
+    r"  \                                                       / ",
+    r"   \             -~~-~-~~-                               /  ",
+    r"    \                                                   /   ",
+    r"     \         -~-~-~-              -~-~-~-            /    ",
+    r"      `.                                             ,'     ",
+    r"        `-,                                       ,-'       ",
+    r"           `~-,                               ,-~'          ",
     r"              `~-,,_                      _,,-~'            ",
     r"                   `~-,,______________,,-~'                 ",
 ];

--- a/src/ui/biscuit.rs
+++ b/src/ui/biscuit.rs
@@ -94,19 +94,24 @@ const BISCUIT_MEDIUM: &[&str] = &[
     r"         `~-,,_______________,,-~'      ",
 ];
 
+// Body walls sit at cols 1 and 25 → visual center column 13. The rounded
+// contour rows (0-3, 9-11) used to terminate one column short of the wall
+// on the right side, leaving a 2-column gap between e.g. `\` (row 3) and
+// `|` (row 4). Symmetrized around col 13 so each row's left margin and
+// right margin are equal — same shape now reads as a closed oval.
 const BISCUIT_SMALL: &[&str] = &[
-    r"        __________        ",
-    r"     ,-~          ~-,     ",
-    r"   ,'                `.   ",
-    r"  /    -~-~-  -~-~-    \  ",
+    r"        ___________       ",
+    r"     ,-~           ~-,    ",
+    r"   ,'                 `.  ",
+    r"  /    -~-~-  -~-~-     \ ",
     r" |       \\\ | ///       | ",
     r" |        \\\|///        | ",
     r" | ~ - -           - - ~ | ",
     r" |        ///|\\\        | ",
     r" |       /// | \\\       | ",
-    r"  \    -~-~-  -~-~-    /  ",
-    r"   `.                ,'   ",
-    r"     `-,,________,,-'     ",
+    r"  \    -~-~-  -~-~-     / ",
+    r"   `.                 ,'  ",
+    r"     `-,,_________,,-'    ",
 ];
 
 const BISCUIT_TINY: &[&str] = &[

--- a/src/ui/biscuit.rs
+++ b/src/ui/biscuit.rs
@@ -177,6 +177,16 @@ pub fn level_count() -> usize {
     BISCUIT_LEVELS.len()
 }
 
+/// Screen coordinates of the focal cell ("the asshole") for the given
+/// zoom level + biscuit rect. Used by `hands::draw` to orbit the ring
+/// around the visual cuque center rather than the bounding-box center
+/// (which differs by up to 1 column in TINY/FULL because each art's
+/// `asshole_col` isn't exactly `width / 2`).
+pub fn focal_point(zoom_idx: usize, biscuit: Rect) -> (u16, u16) {
+    let level = &BISCUIT_LEVELS[zoom_idx.min(BISCUIT_LEVELS.len() - 1)];
+    (biscuit.x + level.asshole_col, biscuit.y + level.asshole_row)
+}
+
 pub fn level_label(idx: usize) -> Option<&'static str> {
     BISCUIT_LEVELS.get(idx).and_then(|a| a.label)
 }

--- a/src/ui/hands.rs
+++ b/src/ui/hands.rs
@@ -15,12 +15,23 @@ const PER_RING: usize = 48;
 /// Mirrors the placement math in `draw()` exactly — keep in sync if either
 /// changes. Cheap: at most `PER_TYPE_CAP * FINGERERS.len()` hand
 /// candidates, and we early-return on the first match.
-pub fn occupied_at(col: u16, row: u16, biscuit: Rect, state: &GameState) -> bool {
+pub fn occupied_at(
+    col: u16,
+    row: u16,
+    biscuit: Rect,
+    focal: (u16, u16),
+    state: &GameState,
+) -> bool {
     if biscuit.width == 0 || biscuit.height == 0 {
         return false;
     }
-    let cx = biscuit.x as f32 + biscuit.width as f32 / 2.0;
-    let cy = biscuit.y as f32 + biscuit.height as f32 / 2.0;
+    // Orbit around the focal cell ("the asshole"), NOT the bbox center.
+    // Each zoom art's `asshole_col` differs from `width / 2` by up to 1
+    // column (TINY: 7 vs 8, FULL: 31 vs 30, etc.), and using the bbox
+    // center makes the ring visibly lopsided around the cuque. Radii
+    // still derive from bbox dimensions — that's the right scale.
+    let cx = focal.0 as f32;
+    let cy = focal.1 as f32;
     let base_rx = (biscuit.width as f32 / 2.0 + 3.0).max(6.0);
     let base_ry = (biscuit.height as f32 / 2.0 + 2.0).max(3.0);
 
@@ -84,13 +95,20 @@ pub fn occupied_at(col: u16, row: u16, biscuit: Rect, state: &GameState) -> bool
     false
 }
 
-pub fn draw(frame: &mut Frame, play_area: Rect, biscuit: Rect, state: &GameState) {
+pub fn draw(
+    frame: &mut Frame,
+    play_area: Rect,
+    biscuit: Rect,
+    focal: (u16, u16),
+    state: &GameState,
+) {
     if play_area.width == 0 || play_area.height == 0 {
         return;
     }
     let buf = frame.buffer_mut();
-    let cx = biscuit.x as f32 + biscuit.width as f32 / 2.0;
-    let cy = biscuit.y as f32 + biscuit.height as f32 / 2.0;
+    // Orbit around the visual focal cell — see comment in `occupied_at`.
+    let cx = focal.0 as f32;
+    let cy = focal.1 as f32;
 
     let base_rx = (biscuit.width as f32 / 2.0 + 3.0).max(6.0);
     let base_ry = (biscuit.height as f32 / 2.0 + 2.0).max(3.0);

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -72,6 +72,12 @@ pub enum HelpAction {
 #[derive(Default)]
 pub struct DrawOutput {
     pub biscuit_rect: Rect,
+    /// Screen position of the biscuit's focal cell ("the asshole"). Each
+    /// zoom level's art has the focal at a slightly different offset
+    /// inside its bounding box (TINY: col 7 of width 16, FULL: col 31 of
+    /// width 60, etc.), so the bbox center isn't the visual center. This
+    /// drives `hands::draw`'s orbit center.
+    pub biscuit_focal: (u16, u16),
     pub golden_rect: Rect,
     /// On-screen Green Coin marker rect, or zero-rect when no coin is
     /// visible. Hit-tested by the click router exactly like `golden_rect`
@@ -288,7 +294,8 @@ pub fn draw(
     frame.render_widget(hud, hud_inner);
 
     let biscuit_rect = biscuit::draw(frame, left[1], state, zoom_idx);
-    hands::draw(frame, left[1], biscuit_rect, state);
+    let biscuit_focal = biscuit::focal_point(zoom_idx, biscuit_rect);
+    hands::draw(frame, left[1], biscuit_rect, biscuit_focal, state);
     effects::draw_particles(frame, biscuit_rect, &state.particles);
     effects::draw_misclicks(frame, &state.misclick_particles);
     draw_zoom_indicator(
@@ -334,6 +341,7 @@ pub fn draw(
 
     DrawOutput {
         biscuit_rect,
+        biscuit_focal,
         golden_rect,
         green_coin_rect,
         play_area: left[1],

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -78,11 +78,13 @@ pub struct DrawOutput {
     /// width 60, etc.), so the bbox center isn't the visual center. This
     /// drives `hands::draw`'s orbit center.
     pub biscuit_focal: (u16, u16),
-    pub golden_rect: Rect,
+    /// One rect per Golden variant slot, indexed by `GoldenVariant as usize`
+    /// (Lucky=0, Frenzy=1, Buff=2). Zero-rect when that slot is empty.
+    /// Each is hit-tested independently — clicking one variant doesn't
+    /// vacuum up an active sibling.
+    pub golden_rects: [Rect; 3],
     /// On-screen Green Coin marker rect, or zero-rect when no coin is
-    /// visible. Hit-tested by the click router exactly like `golden_rect`
-    /// — clicking either one routes through `Action::CatchGolden`, which
-    /// the sim resolves by trying both catch paths.
+    /// visible. Click-routes through `Action::CatchGreenCoin`.
     pub green_coin_rect: Rect,
     /// The whole left column where the biscuit + hands + particles live —
     /// i.e. "the box that displays the ass." Used by the input router so
@@ -307,10 +309,16 @@ pub fn draw(
     if debug {
         debug_pane::draw(frame, left[1]);
     }
-    let golden_rect = match &state.golden {
-        Some(g) => biscuit::draw_golden(frame, g, biscuit_rect),
-        None => Rect::default(),
-    };
+    // Each variant is rendered independently from its own slot. Order
+    // doesn't matter for the visual result — they're at different
+    // fractional positions on the biscuit (sometimes overlapping at
+    // random; that's fine).
+    let mut golden_rects: [Rect; 3] = [Rect::default(); 3];
+    for (i, slot) in state.goldens.iter().enumerate() {
+        if let Some(g) = slot {
+            golden_rects[i] = biscuit::draw_golden(frame, g, biscuit_rect);
+        }
+    }
     let green_coin_rect = match &state.green_coin {
         Some(c) => biscuit::draw_green_coin(frame, c, biscuit_rect),
         None => Rect::default(),
@@ -342,7 +350,7 @@ pub fn draw(
     DrawOutput {
         biscuit_rect,
         biscuit_focal,
-        golden_rect,
+        golden_rects,
         green_coin_rect,
         play_area: left[1],
         upgrade_rows,

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -2,7 +2,9 @@ use ratatui::{prelude::*, widgets::*};
 
 use crate::format;
 use crate::game::fingerer::{self, FINGERERS};
-use crate::game::state::{GameState, PURCHASE_FLASH_TICKS, UNLOCK_FLASH_TICKS};
+use crate::game::state::{
+    GREEN_COIN_ROW_FLASH_TICKS, GameState, PURCHASE_FLASH_TICKS, UNLOCK_FLASH_TICKS,
+};
 use crate::i18n::t;
 use crate::ui::border;
 
@@ -13,6 +15,10 @@ const UNAFFORDABLE_TINT: (f32, f32, f32) = (255.0, 60.0, 60.0);
 /// sits a notch above the regular purchase flash hue so the player can
 /// tell the two events apart on glance.
 const UNLOCK_TINT: (f32, f32, f32) = (120.0, 255.0, 140.0);
+/// Warm gold for the row that just received a Green Coin boost.
+/// Matches the "+10% <fingerer>" particle hue (`ParticleKind::Golden`),
+/// so the eye can track the floating label down to the sidebar row.
+const GREEN_COIN_ROW_TINT: (f32, f32, f32) = (255.0, 215.0, 0.0);
 // Resting color the flash starts from / returns to (neutral gray similar to
 // default terminal text, so the transition in and out is gentle).
 const FLASH_REST: (f32, f32, f32) = (200.0, 200.0, 210.0);
@@ -280,10 +286,16 @@ fn paint_flashes(frame: &mut Frame, area: Rect, state: &GameState, visible: &[us
             .get(fingerer_idx)
             .copied()
             .unwrap_or(0);
+        let green_coin_ticks = state
+            .fingerer_green_coin_flash
+            .get(fingerer_idx)
+            .copied()
+            .unwrap_or(0);
         // Per-row tint priority:
-        //   purchase    (you just bought)        — wins, longest, with bulk amp
+        //   purchase     (you just bought)        — wins, longest, with bulk amp
         //   unaffordable (you tried + failed)    — wins over unlock
-        //   unlock      (just became affordable) — quietly announces the row
+        //   green-coin   (Green Coin landed here) — gold shimmer, ~2s
+        //   unlock       (just became affordable) — quietly announces the row
         // `strength` is the carrier blend (timing only, 0..1); `amp`
         // boosts the wave's tint contribution for bulk buys.
         let (strength, tint, amp) = if purchase_ticks > 0 {
@@ -296,6 +308,12 @@ fn paint_flashes(frame: &mut Frame, area: Rect, state: &GameState, visible: &[us
             (
                 smoothstep(unaff_ticks as f32 / (PURCHASE_FLASH_TICKS as f32 / 2.0)),
                 UNAFFORDABLE_TINT,
+                1.0,
+            )
+        } else if green_coin_ticks > 0 {
+            (
+                smoothstep(green_coin_ticks as f32 / GREEN_COIN_ROW_FLASH_TICKS as f32),
+                GREEN_COIN_ROW_TINT,
                 1.0,
             )
         } else if unlock_ticks > 0 {


### PR DESCRIPTION
A bundle of post-#21 (Green Coin) visual polish + structural cleanup of how powerups spawn and catch. Seven commits, all on `fix-biscuit-small-asymmetry`. Each fix has its own commit and (where applicable) regression test.

## 1. 45% biscuit art was not symmetric around its focal column

`BISCUIT_SMALL` had its right-side rounded contour terminating one column short of where it should: row 3's `\` sat at col 23 while the body wall `|` is at col 25, leaving a visible 2-column gap between the curve and the wall. Same offset on rows 0–3 and 9–11. Symmetrized around col 13 (`asshole_col`) so each row's left and right margins are equal. (`3d773c1`)

## 2. Hands ring orbited the bbox center, not the focal cell

The orbit center for `hands::draw` was `biscuit.x + width / 2`, but the visual focal cell sits at `biscuit.x + asshole_col`, which differs from the bbox center on every zoom level:

| Zoom | asshole_col | bbox center | offset |
|---|---|---|---|
| TINY (25%) | 7 | 8.0 | -1 |
| SMALL (45%) | 13 | 13.5 | -0.5 |
| MEDIUM (70%) | 20 | 20.5 | -0.5 |
| FULL | 31 | 30.0 | +1 |

So the ring orbited 1 column off from where the player perceives the cuque center — most visible at 25% where 1 column is a large fraction of the body width. Fix: add `biscuit::focal_point(zoom_idx, biscuit)`, thread it through `DrawOutput` + `InputContext` (so both native and wasm inherit via the unified `InputContext::from_layout` projection from #23), and use it as the orbit center. Radii still derive from bbox dimensions. (`64393ba`)

## 3. Gold-shimmer the sidebar row that just caught a Green Coin

The catch already produced a floating `+10% {fingerer}` particle in gold and a green title-border pulse, but the player still had to scan the sidebar to find which row's badge had ticked up. Add a 2s gold flash on the targeted row using the same per-row flash-vec pattern as `fingerer_flash_ticks` / `fingerer_unlock_flash` / `fingerer_unaffordable_flash`. Tint priority slots in just above unlock:

> purchase > unaffordable > **green-coin** > unlock

Eye now flows: floating particle → gold-glowing row → the new `+10%` badge. (`598126f`)

## 4. 100% biscuit art was not symmetric around its focal column

`BISCUIT_FULL` had the same shape of bug as 45%: right-side curve rows 2–8 (top) and 21–27 (bottom) extended 1 column further from center than their left-side mirrors. Most visibly at row 8 where `\` landed at col 59 (the same column as the body wall `|` below it), while the left-side `/` sat at col 2 with the wall at col 1 (1-col offset). Right wall thus appeared "inner" relative to the curve while the left wall appeared "outer" — asymmetric, the right side missing its rounded corner offset.

Shifted the right cluster on each curve row 1 col left so the right contour now rounds into the wall the same way the left does. Rows 0, 1, 28, 29 (the underscore cap row + the `__,-~~` row immediately adjacent) sit at half-column offsets from the body center; their |L|/|R| asymmetry is inherent to the even-width middle gap, and a 1-col shift just flips which side is shorter — left as-is. (`9d2c939`)

## 5. Per-variant powerup slots — Lucky/Frenzy/Buff coexist, click catches one only

Two related bugs collapsed into one structural fix:

- **Click on one coin caught both.** `Action::CatchGolden` was unconditionally pushed by every powerup-rect click and the sim's handler called BOTH `state.catch_golden()` AND `state.catch_green_coin()`. Clicking the green marker would also vacuum up an adjacent gold one.
- **Lucky / Frenzy / Buff shared a single `state.golden: Option<GoldenCuque>` slot.** Pressing F2 (Frenzy) replaced an active Lucky on screen, the spawn cooldown bailed if any variant was on screen, and three "different" powerups behaved like one with a tag.

Both fixed by giving every powerup its own slot:

- `state.golden: Option<GoldenCuque>` → `state.goldens: [Option<GoldenCuque>; 3]`, indexed by `GoldenVariant as usize` (Lucky=0, Frenzy=1, Buff=2). Each variant lives in its own independent cell. Spawning Lucky never displaces Frenzy; catching one never disturbs siblings; tick decrements per-slot lifetimes independently.
- `Action::CatchGolden` → `Action::CatchGolden(GoldenVariant)` carries which slot to consume.
- `DrawOutput.golden_rect: Rect` → `DrawOutput.golden_rects: [Rect; 3]`. Each variant renders into its own rect, hit-tested independently. Clicking on Lucky catches only Lucky.
- `g` key + the help-bar `[g]` click both go through a new `push_grab_most_urgent` helper that picks the powerup (across all 4 — Lucky / Frenzy / Buff / Green Coin) with the lowest remaining `life_ticks`. A single press grabs the urgent one; a follow-up press grabs the next-most-urgent. No more accidental multi-catches.

The unified `InputContext::from_layout` projection (#23) means both native and wasm shells inherit the new `golden_rects` field automatically — same single source of truth. wasm + native both build clean with no platform-side updates.

Demo driver (`app.rs::demo_driver_tick`) updated to iterate the slot array; the variant-cycle logic moves a freshly-spawned coin into its target slot when needed. (`447d94b`)

## 6. Per-variant spawn cooldowns — no more synchronized waves

Even with per-variant slots, the spawn cooldown was still shared, AND it had a bug: when the cooldown hit zero and the rolled-variant's slot was already full, the cooldown didn't reset. So the next tick re-rolled instantly. With three variants and 11s lifetimes, this was enough to spawn all three back-to-back as soon as the cooldown hit zero — a single cooldown event would burst-fire 3 (sometimes 4 with Green Coin) coins arriving "at the same time."

Switched to fully independent per-variant cooldowns: `golden_cooldown: u32` → `golden_cooldowns: [u32; 3]`, indexed identically to `goldens`. Each variant's cooldown:

- Initializes to a random value on `Default`, so no two variants arrive at zero simultaneously on a fresh save.
- Freezes while its own slot is occupied (no point counting down to zero with nowhere to spawn).
- Rolls a fresh value on catch / expiry (mirrors original semantics per-variant).

`maybe_spawn_golden` now iterates all three variants each tick and spawns any whose cooldown hit zero AND whose slot is empty. The green-coin pity counter (1% per Golden spawn, accumulating, resets when a Green Coin appears) increments per actual Golden spawn (not per opportunity), preserving the original probability curve. `prestige_reset` rolls all three cooldowns fresh; the demo driver's tighter cooldown override now stamps every variant's slot. (`9d926ea`)

## 7. Rustdoc HTML-tag false-positive

Rustdoc parses `<fingerer>` in doc comments as an unclosed HTML tag, failing CI's `cargo doc -Dwarnings`. Switched to `{fingerer}` brace style which is unambiguous as a placeholder and not HTML. (`35f3903`)

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` (91 passing, +4 from before this branch)
- [x] `cargo check --target wasm32-unknown-unknown` (the new wasm CI gate from #23)
- [x] `RUSTDOCFLAGS=-Dwarnings cargo doc --all-features --no-deps`
- [x] **Visual regression on biscuit symmetry**: PNG screenshots at 100% / 70% / 45% / 25% with a populated multi-tier hands ring; ring orbits cleanly around each cuque size, both walls round symmetrically into their curves.
- [x] **Visual regression on Green Coin catch**: PNG screenshot mid-catch shows targeted sidebar row glowing gold while the floating particle reads `+10% {fingerer}`.
- [x] **Functional regression on per-variant slots**: F8/F2/F3/F5 in sequence leave all 4 powerups on screen simultaneously — clicking any one catches only that one, and `g` picks the most-urgent.
- [x] **Spawn-cadence regression**: under natural play, multi-variant waves no longer arrive together — verified by playtest after the per-variant cooldown fix.

## Tests added

- `attach_modifier_random_visible_can_pick_unowned_when_lifetime_unlocks_it` (already in #21, kept current)
- `force_spawn_does_not_clobber_other_variants` — F8/F2/F3 in sequence leave all three slots populated.
- `catch_golden_only_consumes_targeted_variant` — catching Lucky leaves Frenzy alone.
- `left_click_on_green_coin_emits_green_catch_only` — separate `Action::CatchGreenCoin` path.
- `g_with_both_powerups_picks_lower_life_ticks` — covers urgency ordering across both variant types.