### PR TITLE
V5 save + Mag log-magnitude: unbounded play, orphan fix, rebalance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,11 @@ jobs:
         run: cargo fmt --check
 
       - name: Clippy
-        run: cargo clippy -- -D warnings
+        # `--all-targets` so test-only code is linted too — without it,
+        # warnings inside `#[cfg(test)]` blocks slip past CI and only
+        # surface on developers' machines when they happen to run
+        # `cargo clippy --all-targets` locally.
+        run: cargo clippy --all-targets -- -D warnings
         env:
           RUSTFLAGS: -Dwarnings
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /target
 /dist
+# Claude Code's scheduled-task lock — per-checkout runtime artifact, never code.
+.claude/scheduled_tasks.lock

--- a/src/app.rs
+++ b/src/app.rs
@@ -349,7 +349,7 @@ fn demo_driver_tick(
     // hit; gives the demo a steady visible tree-spread without needing
     // to plan a route.
     if t.is_multiple_of(160) {
-        let mut best: Option<(TreeCoord, f64)> = None;
+        let mut best: Option<(TreeCoord, crate::bignum::Mag)> = None;
         for &owned in &state.tree.bought {
             for n in crate::game::tree::node::neighbors_of(owned) {
                 if state.tree.bought.contains(&n) {
@@ -509,18 +509,14 @@ pub fn build_demo_state() -> GameState {
     let mut s = GameState {
         // Low relative to FPS so the counter clearly grows throughout
         // the clip, and cheap enough to buy early tiers often.
-        cuques: 500_000.0,
-        lifetime_cuques: 500_000_000.0, // unlocks all tiers via the visibility gate
+        cuques: crate::bignum::Mag::from_f64(500_000.0),
+        lifetime_cuques: crate::bignum::Mag::from_f64(500_000_000.0),
         total_clicks: 500,
-        total_play_ticks: 3600 * TICK_HZ as u64, // pretend we've been at this an hour
+        total_play_ticks: 3600 * TICK_HZ as u64,
         prestige: 3,
         golden_caught: 7,
-        // Default seeds each per-kind cooldown from a fresh exponential
-        // sample (60-240s mean depending on kind). For the demo we zero
-        // them all so the first powerup (a Buff, per the cycle in
-        // demo_driver_tick) lands well within the first few seconds.
         powerup_cooldowns: [0; powerup::N_KINDS],
-        best_fps: 50_000.0,
+        best_fps: crate::bignum::Mag::from_f64(50_000.0),
         ..GameState::default()
     };
     // Seed counts/flags BY CATALOG INDEX rather than by hardcoded id strings,

--- a/src/bignum.rs
+++ b/src/bignum.rs
@@ -1,0 +1,455 @@
+//! `Mag` — a non-negative real represented as `log10(value)`.
+//!
+//! The whole point: gameplay-side quantities (cuques, FPS, tree multipliers,
+//! per-fingerer modifier mults) compound multiplicatively across thousands
+//! of bought nodes and powerup catches. Stored as `f64`, the product
+//! reaches `Infinity` after a long-haul session — the headline bug from
+//! the wild "broken save" triage. Stored as `log10`, the same product
+//! fits comfortably inside an `f64` for any value the player could
+//! conceivably observe; the dynamic range is `10^(±1.8e308)`, i.e.
+//! "truly infinite" for any practical gameplay.
+//!
+//! ## Representation
+//!
+//! `Mag { log10: f64 }`, where `log10` is the base-10 logarithm of the
+//! value. Zero is the sentinel `log10 == f64::NEG_INFINITY`; everything
+//! else is finite. Negatives are not representable (the only place the
+//! game produced one was an underflow that signalled a bug anyway —
+//! `try_sub` returns `Option`, callers handle the deficit explicitly).
+//!
+//! ## Operations
+//!
+//! - `mul` / `div`: addition / subtraction in log space — cheap.
+//! - `add`: requires un-logging the smaller addend; uses
+//!   `log10(a + b) = log10(a) + log10(1 + 10^(b - a))` for `a >= b`.
+//! - `try_sub`: same trick. Returns `None` if the result would be
+//!   negative.
+//! - `cmp`: direct comparison of the log values.
+//! - `to_f64`: useful at display sites (for the legacy `format::big`
+//!   path) and inside formulas that need a real `f64` (e.g. RNG range
+//!   bounds, multiplier caps from the procgen).
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+/// Non-negative log-magnitude. `Mag::ZERO == Mag { log10: -inf }`,
+/// `Mag::ONE == Mag { log10: 0.0 }`. All other instances carry a
+/// finite `log10`.
+///
+/// ## Save compatibility
+///
+/// Serializes as a plain `f64` when the value fits inside one
+/// (`log10 < 300`, well clear of overflow); otherwise as
+/// `{"log10": <f64>}`. Deserialization accepts BOTH shapes — so existing
+/// V4 saves with `"cuques": 1.234e10` and `"MulFactor": 7.0` continue
+/// to load correctly, no schema bump required. New saves use the
+/// struct form only when the value exceeds the `f64` finite range.
+#[derive(Clone, Copy, Debug)]
+pub struct Mag {
+    pub log10: f64,
+}
+
+impl Serialize for Mag {
+    fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        // Below the `f64` overflow horizon, emit a plain number so saves
+        // stay human-readable and old-format-compatible. Above it, fall
+        // back to the explicit struct so the log-magnitude survives the
+        // round-trip exactly.
+        if self.log10 == f64::NEG_INFINITY {
+            return 0.0_f64.serialize(s);
+        }
+        if self.log10 < 300.0 {
+            return self.to_f64().serialize(s);
+        }
+        // Struct form for truly-huge values.
+        #[derive(Serialize)]
+        struct Wide {
+            log10: f64,
+        }
+        Wide { log10: self.log10 }.serialize(s)
+    }
+}
+
+impl<'de> Deserialize<'de> for Mag {
+    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        // Accept either a plain JSON number (legacy + small new saves)
+        // or the explicit `{"log10": ...}` struct (large new saves). The
+        // untagged enum gives serde the freedom to try both without us
+        // hand-writing a visitor.
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum Either {
+            Number(f64),
+            Struct { log10: f64 },
+        }
+        match Either::deserialize(d)? {
+            Either::Number(v) => Ok(Mag::from_f64(v)),
+            Either::Struct { log10 } => Ok(Mag { log10 }),
+        }
+    }
+}
+
+impl Mag {
+    pub const ZERO: Mag = Mag {
+        log10: f64::NEG_INFINITY,
+    };
+    pub const ONE: Mag = Mag { log10: 0.0 };
+
+    /// Construct from an `f64`. Non-finite / negative inputs collapse to
+    /// `ZERO` — there is no honest log-magnitude for them and silently
+    /// turning a `NaN` into a zero is friendlier than panicking on a
+    /// codepath the player never asked for.
+    pub fn from_f64(v: f64) -> Mag {
+        if !v.is_finite() || v <= 0.0 {
+            Mag::ZERO
+        } else {
+            Mag { log10: v.log10() }
+        }
+    }
+
+    /// Decode back to an `f64`. Clamps very-large `log10` values to
+    /// `f64::MAX` — losing precision in the high end is the price of
+    /// asking for an `f64`; the `Mag` representation itself stays
+    /// faithful. Use this at the display boundary or wherever a downstream
+    /// API truly demands `f64`. Internal math should chain `Mag` ops.
+    pub fn to_f64(self) -> f64 {
+        if self.log10.is_nan() {
+            return 0.0;
+        }
+        if self.log10 == f64::NEG_INFINITY {
+            return 0.0;
+        }
+        if self.log10 >= f64::MAX.log10() {
+            return f64::MAX;
+        }
+        10f64.powf(self.log10)
+    }
+
+    pub fn is_zero(self) -> bool {
+        self.log10 == f64::NEG_INFINITY
+    }
+
+    // `clippy::should_implement_trait` would have us drop the inherent
+    // method in favor of the `std::ops::Mul` impl below. We keep both
+    // because the call sites read more naturally as `a.mul(b)` than
+    // `Mag::Mul::mul(a, b)` and the `*` operator alone obscures that
+    // Mag isn't a primitive `f64`. The trait impl exists so `*` works
+    // and so the inherent method is provably aligned with std semantics.
+    #[allow(clippy::should_implement_trait)]
+    pub fn mul(self, rhs: Mag) -> Mag {
+        if self.is_zero() || rhs.is_zero() {
+            return Mag::ZERO;
+        }
+        Mag {
+            log10: self.log10 + rhs.log10,
+        }
+    }
+
+    #[allow(clippy::should_implement_trait)]
+    pub fn div(self, rhs: Mag) -> Mag {
+        if self.is_zero() {
+            return Mag::ZERO;
+        }
+        if rhs.is_zero() {
+            // Defining 1/0 as ZERO here is a deliberate, defensive
+            // choice: nothing in gameplay should ever divide by zero,
+            // but if it does we'd rather collapse to "no contribution"
+            // than panic or produce an `Infinity` that re-introduces
+            // the bug class this whole module exists to kill.
+            return Mag::ZERO;
+        }
+        Mag {
+            log10: self.log10 - rhs.log10,
+        }
+    }
+
+    #[allow(clippy::should_implement_trait)]
+    pub fn add(self, rhs: Mag) -> Mag {
+        if self.is_zero() {
+            return rhs;
+        }
+        if rhs.is_zero() {
+            return self;
+        }
+        let (hi, lo) = if self.log10 >= rhs.log10 {
+            (self.log10, rhs.log10)
+        } else {
+            (rhs.log10, self.log10)
+        };
+        let diff = lo - hi;
+        if diff < -16.0 {
+            // 10^-16 is past f64 precision relative to 1.0 — the smaller
+            // addend's contribution rounds away. Skip the (1.0 + 10^diff)
+            // dance and return the larger.
+            return Mag { log10: hi };
+        }
+        Mag {
+            log10: hi + (1.0 + 10f64.powf(diff)).log10(),
+        }
+    }
+
+    /// Saturating subtraction: returns `Some(self - rhs)` when
+    /// `self >= rhs`, otherwise `None`. Cuque spending uses this on
+    /// purchase — the caller already gated on `affordable`, so `None`
+    /// means a logic bug, not a regular game state.
+    pub fn try_sub(self, rhs: Mag) -> Option<Mag> {
+        if rhs.is_zero() {
+            return Some(self);
+        }
+        if self.log10 < rhs.log10 {
+            return None;
+        }
+        if self.is_zero() {
+            return Some(Mag::ZERO);
+        }
+        let diff = rhs.log10 - self.log10;
+        if diff < -16.0 {
+            return Some(self);
+        }
+        let factor = 1.0 - 10f64.powf(diff);
+        if factor <= 0.0 {
+            return Some(Mag::ZERO);
+        }
+        Some(Mag {
+            log10: self.log10 + factor.log10(),
+        })
+    }
+
+    /// Saturating subtraction with floor at zero. Convenience for paths
+    /// that don't care about the underflow case (e.g. visual tween
+    /// targets).
+    pub fn saturating_sub(self, rhs: Mag) -> Mag {
+        self.try_sub(rhs).unwrap_or(Mag::ZERO)
+    }
+
+    /// Raise to an integer power. `pow(0) == ONE`, `pow(n) = self * self * …`.
+    /// Cheap: just multiplies the log by `n`.
+    ///
+    /// `0^n` for any `n != 0` returns `ZERO`. Mathematically `0^negative` is
+    /// undefined, but returning ZERO is the conservative choice for this
+    /// codebase: it propagates "no contribution" downstream rather than
+    /// producing an `Infinity`, which would reintroduce the bug class
+    /// the `Mag` type exists to kill.
+    pub fn pow_i(self, n: i32) -> Mag {
+        if n == 0 {
+            return Mag::ONE;
+        }
+        if self.is_zero() {
+            return Mag::ZERO;
+        }
+        Mag {
+            log10: self.log10 * (n as f64),
+        }
+    }
+
+    /// Floored `to_f64`, useful for "how many of these can the player
+    /// afford" math. Clamps to `u64::MAX`.
+    pub fn floor_u64(self) -> u64 {
+        let v = self.to_f64().floor();
+        if v <= 0.0 {
+            0
+        } else if v >= u64::MAX as f64 {
+            u64::MAX
+        } else {
+            v as u64
+        }
+    }
+}
+
+impl Default for Mag {
+    fn default() -> Self {
+        Mag::ZERO
+    }
+}
+
+impl PartialEq for Mag {
+    fn eq(&self, other: &Self) -> bool {
+        // NaN-safe: treat any NaN log as ZERO for equality purposes.
+        let a = if self.log10.is_nan() {
+            f64::NEG_INFINITY
+        } else {
+            self.log10
+        };
+        let b = if other.log10.is_nan() {
+            f64::NEG_INFINITY
+        } else {
+            other.log10
+        };
+        a == b
+    }
+}
+
+impl PartialOrd for Mag {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        self.log10.partial_cmp(&other.log10)
+    }
+}
+
+// Convenience: ergonomic conversion from common literal types so call
+// sites can keep reading naturally ("Mag::from(0.05)" inside a test
+// fixture).
+impl From<f64> for Mag {
+    fn from(v: f64) -> Self {
+        Mag::from_f64(v)
+    }
+}
+
+impl From<u32> for Mag {
+    fn from(v: u32) -> Self {
+        Mag::from_f64(v as f64)
+    }
+}
+
+impl From<u64> for Mag {
+    fn from(v: u64) -> Self {
+        Mag::from_f64(v as f64)
+    }
+}
+
+// Operator traits forward to the inherent methods so `a * b` / `a + b` /
+// `a / b` work alongside the explicit `.mul(b)` / `.add(b)` / `.div(b)`
+// the rest of the codebase uses. The trait impls also silence clippy's
+// `method_can_be_confused_for_std_trait` warning — the methods *are*
+// the standard operations now.
+//
+// Subtraction deliberately doesn't get a `Sub` impl: the only honest
+// answer for `a - b` when `b > a` is "underflow", and `try_sub →
+// Option` keeps every spend site forced to acknowledge that case.
+
+impl std::ops::Mul for Mag {
+    type Output = Mag;
+    fn mul(self, rhs: Mag) -> Mag {
+        Mag::mul(self, rhs)
+    }
+}
+
+impl std::ops::Div for Mag {
+    type Output = Mag;
+    fn div(self, rhs: Mag) -> Mag {
+        Mag::div(self, rhs)
+    }
+}
+
+impl std::ops::Add for Mag {
+    type Output = Mag;
+    fn add(self, rhs: Mag) -> Mag {
+        Mag::add(self, rhs)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn approx_eq(a: f64, b: f64) -> bool {
+        if a == b {
+            return true;
+        }
+        (a - b).abs() / b.abs().max(1e-12) < 1e-10
+    }
+
+    #[test]
+    fn from_f64_roundtrip() {
+        for v in [1.0, 1000.0, 1e20, 1e100, 1e300] {
+            let m = Mag::from_f64(v);
+            assert!(approx_eq(m.to_f64(), v), "roundtrip {v} got {}", m.to_f64());
+        }
+    }
+
+    #[test]
+    fn zero_and_negative_collapse_to_zero() {
+        assert_eq!(Mag::from_f64(0.0), Mag::ZERO);
+        assert_eq!(Mag::from_f64(-5.0), Mag::ZERO);
+        assert_eq!(Mag::from_f64(f64::NAN), Mag::ZERO);
+        assert_eq!(Mag::from_f64(f64::INFINITY), Mag::ZERO);
+    }
+
+    #[test]
+    fn mul_compounds_huge() {
+        let a = Mag::from_f64(1e200);
+        let b = Mag::from_f64(1e200);
+        let c = a.mul(b);
+        // 10^400 — well past f64::MAX.
+        assert!(approx_eq(c.log10, 400.0));
+        // to_f64 saturates rather than producing infinity.
+        assert_eq!(c.to_f64(), f64::MAX);
+    }
+
+    #[test]
+    fn pow_i_handles_grindy_compounding() {
+        // 1.005^100_000 — a stress test for late-late-game stacks.
+        // Original f64 path would overflow long before this.
+        let m = Mag::from_f64(1.005);
+        let p = m.pow_i(100_000);
+        let expected_log = (1.005_f64).log10() * 100_000.0;
+        assert!(approx_eq(p.log10, expected_log));
+    }
+
+    #[test]
+    fn add_handles_disparate_magnitudes() {
+        // 10^100 + 10^50 ≈ 10^100 (within f64 precision).
+        let a = Mag::from_f64(1e100);
+        let b = Mag::from_f64(1e50);
+        let s = a.add(b);
+        assert!(approx_eq(s.log10, a.log10));
+    }
+
+    #[test]
+    fn add_handles_equal_magnitudes() {
+        let a = Mag::from_f64(1e100);
+        let s = a.add(a);
+        // 2 * 10^100 -> log10 = 100 + log10(2)
+        assert!(approx_eq(s.log10, 100.0 + 2.0_f64.log10()));
+    }
+
+    #[test]
+    fn try_sub_returns_none_on_underflow() {
+        let a = Mag::from_f64(100.0);
+        let b = Mag::from_f64(200.0);
+        assert!(a.try_sub(b).is_none());
+    }
+
+    #[test]
+    fn try_sub_handles_close_values() {
+        let a = Mag::from_f64(100.0);
+        let b = Mag::from_f64(99.0);
+        let s = a.try_sub(b).expect("should fit");
+        assert!(approx_eq(s.to_f64(), 1.0));
+    }
+
+    #[test]
+    fn try_sub_zero_is_identity() {
+        let a = Mag::from_f64(50.0);
+        assert_eq!(a.try_sub(Mag::ZERO).unwrap(), a);
+    }
+
+    #[test]
+    fn comparison_order_matches_value_order() {
+        assert!(Mag::from_f64(10.0) < Mag::from_f64(100.0));
+        assert!(Mag::ZERO < Mag::from_f64(1.0));
+        // Truly huge values still order correctly.
+        assert!(Mag::from_f64(1e200).mul(Mag::from_f64(1e200)) > Mag::from_f64(1e300));
+    }
+
+    #[test]
+    fn mul_by_zero_is_zero() {
+        let a = Mag::from_f64(1e100);
+        assert_eq!(a.mul(Mag::ZERO), Mag::ZERO);
+    }
+
+    #[test]
+    fn one_is_multiplicative_identity() {
+        let a = Mag::from_f64(42.0);
+        assert!(approx_eq(a.mul(Mag::ONE).to_f64(), a.to_f64()));
+        assert!(approx_eq(Mag::ONE.mul(a).to_f64(), a.to_f64()));
+    }
+
+    #[test]
+    fn floor_u64_clamps_at_u64_max() {
+        let huge = Mag::from_f64(1e25);
+        // 10^25 > u64::MAX (~1.8e19), should clamp.
+        assert_eq!(huge.floor_u64(), u64::MAX);
+        let small = Mag::from_f64(42.7);
+        assert_eq!(small.floor_u64(), 42);
+        assert_eq!(Mag::ZERO.floor_u64(), 0);
+    }
+}

--- a/src/format.rs
+++ b/src/format.rs
@@ -1,25 +1,181 @@
-const SUFFIXES: &[&str] = &[
+/// Short suffixes for the first 12 engineering steps (10^0 … 10^33).
+/// After Decillion the formatter switches to an *infinite* alphabetic
+/// scheme (see `alpha_suffix`).
+const KNOWN_SUFFIXES: &[&str] = &[
     "", "k", "M", "B", "T", "Qa", "Qi", "Sx", "Sp", "Oc", "No", "Dc",
 ];
 
+/// Format a `Mag` (log-magnitude) the same way `big` formats an `f64`,
+/// but without an upper bound on representable values. Cuques, FPS,
+/// and costs all flow through here once they live in `Mag` form.
+pub fn big_mag(m: crate::bignum::Mag) -> String {
+    if m.is_zero() {
+        return "0".into();
+    }
+    if m.log10 < 3.0 {
+        // Below 1000 — defer to the regular `big()` path for parity
+        // with how the game has always rendered small early-game
+        // numbers (plain integer, no suffix).
+        return big(m.to_f64());
+    }
+    // Engineering-group: every 3 OOM gets a suffix.
+    // `log10 / 3.0` for normal play never exceeds a few thousand, so
+    // the as-i64 cast is safe; the upper-bound clamp guards a runaway
+    // future bug from indexing past the alpha-suffix horizon.
+    let raw_group = (m.log10 / 3.0).floor();
+    if !raw_group.is_finite() || raw_group > 1e15 {
+        // Past `10^(3e15)` we've left any reasonable gameplay regime —
+        // emit a compact log-space label so the HUD still says something
+        // useful instead of stalling on an infinite suffix lookup.
+        return format!("10^{:.0}", m.log10);
+    }
+    let group = raw_group as usize;
+    let suffix = if group < KNOWN_SUFFIXES.len() {
+        KNOWN_SUFFIXES[group].to_string()
+    } else {
+        alpha_suffix(group - KNOWN_SUFFIXES.len())
+    };
+    let scaled = 10f64.powf(m.log10 - (group as f64) * 3.0);
+    format!("{scaled:.2}{suffix}")
+}
+
 pub fn big(n: f64) -> String {
     if n.is_nan() || n.is_infinite() {
+        // Bug sentinel: the gameplay math should never reach Inf/NaN
+        // with the rebalanced tree magnitudes. If we ever see `?` in
+        // game again, something has overflowed and needs investigating.
         return "?".into();
     }
-    if n < 1000.0 {
-        return format!("{}", n.floor() as u64);
+    if n.abs() < 1000.0 {
+        return format!("{}", n.floor() as i64);
     }
-    let mag = (n.log10() / 3.0).floor() as i32;
-    let idx = mag.clamp(0, (SUFFIXES.len() - 1) as i32) as usize;
-    let scaled = n / 10f64.powi((idx * 3) as i32);
-    format!("{:.2}{}", scaled, SUFFIXES[idx])
+    let mag = (n.abs().log10() / 3.0).floor() as i32;
+    let mag = mag.max(0) as usize;
+    let suffix = if mag < KNOWN_SUFFIXES.len() {
+        KNOWN_SUFFIXES[mag].to_string()
+    } else {
+        alpha_suffix(mag - KNOWN_SUFFIXES.len())
+    };
+    let scaled = n / 10f64.powi((mag * 3) as i32);
+    format!("{scaled:.2}{suffix}")
+}
+
+/// Infinite alphabetic suffix sequence. `n=0` yields the first suffix
+/// past Decillion. The sequence is grouped into *phases*; phase `L≥0`
+/// produces all `(L+2)`-letter strings, first all-lowercase, then
+/// capital-first. Each phase has `2 × 26^(L+2)` entries.
+///
+/// Concretely:
+///
+/// ```text
+/// n = 0..676            → aa, ab, …, az, ba, …, zz       (676 = 26²  lowercase pairs)
+/// n = 676..1352         → Aa, Ab, …, Az, Ba, …, Zz        (676  uppercase-first pairs)
+/// n = 1352..1352+17576  → aaa, aab, …, zzz               (17576 = 26³  lowercase triples)
+/// n = …  + 17576        → Aaa, Aab, …, Zzz                (uppercase-first triples)
+/// …
+/// ```
+///
+/// Each suffix step represents three more orders of magnitude on top of
+/// `10^33 ≈ Dc`, so phase 0 alone covers `10^36 … 10^(33 + 676·3)` =
+/// `10^36 … 10^2061` — already past `f64::MAX ≈ 1.8e308`. The higher
+/// phases exist so the helper remains correct under any future
+/// arbitrary-precision number type.
+pub fn alpha_suffix(mut n: usize) -> String {
+    let mut len: u32 = 2;
+    loop {
+        let phase_entries = 26usize.pow(len);
+        // Phase L, sub-phase 0: lowercase only.
+        if n < phase_entries {
+            return digits_to_letters(n, len as usize, false);
+        }
+        n -= phase_entries;
+        // Phase L, sub-phase 1: capital-first.
+        if n < phase_entries {
+            return digits_to_letters(n, len as usize, true);
+        }
+        n -= phase_entries;
+        len += 1;
+    }
+}
+
+/// Encode `idx` as a `len`-digit base-26 numeral with leading zeros,
+/// emitting `a..z` for each digit. If `cap_first` is true, capitalize
+/// the leading letter (e.g. `Aa`, `Aaa`).
+fn digits_to_letters(mut idx: usize, len: usize, cap_first: bool) -> String {
+    let mut digits = vec![0u8; len];
+    for i in (0..len).rev() {
+        digits[i] = (idx % 26) as u8;
+        idx /= 26;
+    }
+    digits
+        .iter()
+        .enumerate()
+        .map(|(i, &d)| {
+            let base = if i == 0 && cap_first { b'A' } else { b'a' };
+            (base + d) as char
+        })
+        .collect()
+}
+
+/// Render a multiplicative magnitude (e.g. a `MulFactor`/`EffectMul` value)
+/// with enough decimal places to show ~3 significant figures of its
+/// distance from `1.0`. Lets per-tree-node values like `1.00004` actually
+/// read as `×1.00004` in the info pane instead of getting rounded to the
+/// uninformative `×1.00`.
+pub fn mul_magnitude(v: f64) -> String {
+    let delta = (v - 1.0).abs();
+    if delta == 0.0 || !v.is_finite() {
+        return format!("×{v:.2}");
+    }
+    // Sig-figs of the delta determine precision: `delta = 1e-4` → 6
+    // decimals (so the user sees `×1.00010`), `delta = 0.5` → 2 decimals
+    // (`×1.50`). Clamped to [2, 8] so we never write e.g. `×1.5` (too
+    // few) or `×1.00000123456` (visual noise).
+    let need = (-delta.log10()).ceil() as i32 + 2;
+    let prec = need.clamp(2, 8) as usize;
+    format!("×{v:.*}", prec)
+}
+
+/// Like `mul_magnitude`, but for an `AddPercent` magnitude (raw `f64`
+/// where `0.01 == 1%`). Picks decimal precision so the user can see
+/// sub-percent values like `+0.005%` that would otherwise round to
+/// `+0.0%`.
+pub fn percent_magnitude(v: f64) -> String {
+    let p = v * 100.0;
+    let mag = p.abs();
+    let prec = if mag >= 1.0 {
+        1
+    } else if mag >= 0.1 {
+        2
+    } else if mag >= 0.01 {
+        3
+    } else {
+        4
+    };
+    format!("{p:+.*}%", prec)
+}
+
+/// Like `mul_magnitude`, but for a `FlatAdd` magnitude. Picks decimal
+/// precision so a 0.002 FlatAdd doesn't collapse to `+0.0`.
+pub fn flat_magnitude(v: f64) -> String {
+    let m = v.abs();
+    let prec = if m >= 10.0 {
+        1
+    } else if m >= 1.0 {
+        2
+    } else if m >= 0.1 {
+        3
+    } else {
+        4
+    };
+    format!("{v:+.*}", prec)
 }
 
 pub fn rate(n: f64) -> String {
     if n < 10.0 {
-        format!("{:.2}", n)
+        format!("{n:.2}")
     } else if n < 100.0 {
-        format!("{:.1}", n)
+        format!("{n:.1}")
     } else {
         big(n)
     }
@@ -30,10 +186,98 @@ pub fn duration(secs: u64) -> String {
     let m = (secs % 3600) / 60;
     let s = secs % 60;
     if h > 0 {
-        format!("{}h {:02}m {:02}s", h, m, s)
+        format!("{h}h {m:02}m {s:02}s")
     } else if m > 0 {
-        format!("{}m {:02}s", m, s)
+        format!("{m}m {s:02}s")
     } else {
-        format!("{}s", s)
+        format!("{s}s")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn small_numbers_are_plain_integers() {
+        assert_eq!(big(0.0), "0");
+        assert_eq!(big(42.7), "42");
+        assert_eq!(big(999.0), "999");
+    }
+
+    #[test]
+    fn known_suffix_range_uses_short_names() {
+        assert_eq!(big(1_500.0), "1.50k");
+        assert_eq!(big(2.5e6), "2.50M");
+        assert_eq!(big(7.0e33), "7.00Dc");
+    }
+
+    #[test]
+    fn beyond_decillion_uses_alpha_suffix() {
+        // 10^36 is the first step past Decillion.
+        assert_eq!(big(1.0e36), "1.00aa");
+        assert_eq!(big(3.5e36), "3.50aa");
+        assert_eq!(big(1.0e39), "1.00ab");
+        assert_eq!(big(1.0e42), "1.00ac");
+    }
+
+    #[test]
+    fn alpha_suffix_phase_transitions() {
+        // First lowercase pair (n=0) is "aa".
+        assert_eq!(alpha_suffix(0), "aa");
+        // Last lowercase pair (n=675) is "zz".
+        assert_eq!(alpha_suffix(675), "zz");
+        // Then uppercase-first pairs start at n=676 with "Aa".
+        assert_eq!(alpha_suffix(676), "Aa");
+        // Last uppercase-first pair (n=1351) is "Zz".
+        assert_eq!(alpha_suffix(1351), "Zz");
+        // Then lowercase triples begin at n=1352 with "aaa".
+        assert_eq!(alpha_suffix(1352), "aaa");
+    }
+
+    #[test]
+    fn alpha_suffix_within_phase_is_base26() {
+        // n=1 → "ab", n=25 → "az", n=26 → "ba".
+        assert_eq!(alpha_suffix(1), "ab");
+        assert_eq!(alpha_suffix(25), "az");
+        assert_eq!(alpha_suffix(26), "ba");
+    }
+
+    #[test]
+    fn infinity_and_nan_render_as_question_mark() {
+        assert_eq!(big(f64::INFINITY), "?");
+        assert_eq!(big(f64::NEG_INFINITY), "?");
+        assert_eq!(big(f64::NAN), "?");
+    }
+
+    #[test]
+    fn big_mag_handles_unbounded_values() {
+        use crate::bignum::Mag;
+        // 10^36 → first alpha-suffix entry.
+        assert_eq!(big_mag(Mag::from_f64(1.0e36)), "1.00aa");
+        // 10^999 — past f64::MAX, but Mag handles it cleanly. Pick
+        // a power that's an exact multiple of 3 so the mantissa is "1".
+        let huge = Mag { log10: 999.0 };
+        let s = big_mag(huge);
+        assert!(!s.contains('?'), "got {s}");
+        assert!(s.starts_with("1.00"), "got {s}");
+    }
+
+    #[test]
+    fn big_mag_handles_zero_and_small() {
+        use crate::bignum::Mag;
+        assert_eq!(big_mag(Mag::ZERO), "0");
+        assert_eq!(big_mag(Mag::from_f64(42.0)), "42");
+        assert_eq!(big_mag(Mag::from_f64(1500.0)), "1.50k");
+    }
+
+    #[test]
+    fn huge_but_finite_number_does_not_print_question_mark() {
+        // 1e200 would have overflowed the old fixed-suffix table and
+        // produced a stretch of trailing zeros in front of "Dc". With
+        // the alpha tail it formats compactly with a real suffix.
+        let s = big(1.0e200);
+        assert!(!s.contains('?'), "got {s}");
+        assert!(s.ends_with(char::is_alphabetic), "got {s}");
     }
 }

--- a/src/game/achievement.rs
+++ b/src/game/achievement.rs
@@ -17,15 +17,15 @@ pub const ACHIEVEMENTS: &[AchievementKind] = &[
     },
     AchievementKind {
         id: "warming_up",
-        unlocked: |s| s.lifetime_cuques >= 100.0,
+        unlocked: |s| s.lifetime_cuques >= crate::bignum::Mag::from_f64(100.0),
     },
     AchievementKind {
         id: "seasoned_fingerer",
-        unlocked: |s| s.lifetime_cuques >= 10_000.0,
+        unlocked: |s| s.lifetime_cuques >= crate::bignum::Mag::from_f64(10_000.0),
     },
     AchievementKind {
         id: "cuque_mogul",
-        unlocked: |s| s.lifetime_cuques >= 1_000_000.0,
+        unlocked: |s| s.lifetime_cuques >= crate::bignum::Mag::from_f64(1_000_000.0),
     },
     AchievementKind {
         id: "automation",

--- a/src/game/modifier.rs
+++ b/src/game/modifier.rs
@@ -40,6 +40,8 @@
 
 use serde::{Deserialize, Serialize};
 
+use crate::bignum::Mag;
+
 /// Stable identifier for the *kind* of buff or debuff a modifier represents.
 /// Used for de-duping in the UI ("3× Green Coin" instead of three identical
 /// chips), for save serialization, and for future per-source rules.
@@ -71,6 +73,14 @@ impl ModifierSource {
 /// One contribution from a modifier. A single [`Modifier`] may carry
 /// multiple effects — e.g. a future debuff could combine
 /// `[FlatFps(-10.0), MulFactor(0.5)]`.
+///
+/// `MulFactor` carries a [`Mag`] (log-magnitude) so the catch-time
+/// product `7.0 × tree.powerup_reward_mul[Buff]` can grow truly
+/// unboundedly across late-game stacks without overflowing `f64`. The
+/// `Mag` (de)serializer accepts both raw JSON numbers (legacy V4 saves
+/// stored `"MulFactor": 7.0`) and the explicit `{"log10": …}` form (new
+/// huge values), so the change is wire-compatible — no save version
+/// bump.
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq)]
 pub enum ModifierEffect {
     /// Flat additive contribution to the fingerer's per-tier output.
@@ -81,7 +91,7 @@ pub enum ModifierEffect {
     AddPercent(f64),
     /// Multiplicative factor. Multiplies across all modifiers on the
     /// fingerer (two x2 = x4). Applied after [`Self::AddPercent`].
-    MulFactor(f64),
+    MulFactor(Mag),
 }
 
 /// Lifetime of a modifier. Permanent modifiers stick for the rest of the
@@ -148,7 +158,7 @@ impl Modifier {
 pub struct FingererAggregate {
     pub flat_fps: f64,
     pub add_percent: f64,
-    pub mul_factor: f64,
+    pub mul_factor: Mag,
 }
 
 impl Default for FingererAggregate {
@@ -156,7 +166,7 @@ impl Default for FingererAggregate {
         Self {
             flat_fps: 0.0,
             add_percent: 0.0,
-            mul_factor: 1.0,
+            mul_factor: Mag::ONE,
         }
     }
 }
@@ -171,7 +181,7 @@ impl FingererAggregate {
                 match *e {
                     ModifierEffect::FlatFps(v) => a.flat_fps += v,
                     ModifierEffect::AddPercent(v) => a.add_percent += v,
-                    ModifierEffect::MulFactor(v) => a.mul_factor *= v,
+                    ModifierEffect::MulFactor(v) => a.mul_factor = a.mul_factor.mul(v),
                 }
             }
         }
@@ -192,17 +202,20 @@ mod tests {
         }
     }
 
+    fn mul(v: f64) -> ModifierEffect {
+        ModifierEffect::MulFactor(Mag::from_f64(v))
+    }
+
     #[test]
     fn empty_aggregate_is_identity() {
         let a = FingererAggregate::rebuild(&[]);
         assert_eq!(a.flat_fps, 0.0);
         assert_eq!(a.add_percent, 0.0);
-        assert_eq!(a.mul_factor, 1.0);
+        assert_eq!(a.mul_factor, Mag::ONE);
     }
 
     #[test]
     fn add_percent_sums_across_modifiers() {
-        // Two +10% Green Coins → +20%, NOT compounded into +21%.
         let mods = vec![
             perm(vec![ModifierEffect::AddPercent(0.10)]),
             perm(vec![ModifierEffect::AddPercent(0.10)]),
@@ -213,13 +226,9 @@ mod tests {
 
     #[test]
     fn mul_factor_multiplies_across_modifiers() {
-        // Two x2 buffs → x4.
-        let mods = vec![
-            perm(vec![ModifierEffect::MulFactor(2.0)]),
-            perm(vec![ModifierEffect::MulFactor(2.0)]),
-        ];
+        let mods = vec![perm(vec![mul(2.0)]), perm(vec![mul(2.0)])];
         let a = FingererAggregate::rebuild(&mods);
-        assert!((a.mul_factor - 4.0).abs() < 1e-9);
+        assert!((a.mul_factor.to_f64() - 4.0).abs() < 1e-9);
     }
 
     #[test]
@@ -237,12 +246,23 @@ mod tests {
         let mods = vec![perm(vec![
             ModifierEffect::FlatFps(50.0),
             ModifierEffect::AddPercent(0.10),
-            ModifierEffect::MulFactor(2.0),
+            mul(2.0),
         ])];
         let a = FingererAggregate::rebuild(&mods);
         assert!((a.flat_fps - 50.0).abs() < 1e-9);
         assert!((a.add_percent - 0.10).abs() < 1e-9);
-        assert!((a.mul_factor - 2.0).abs() < 1e-9);
+        assert!((a.mul_factor.to_f64() - 2.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn mul_factor_stack_survives_billions() {
+        // Stack 10k MulFactor(1.5) modifiers — under the old f64 path
+        // this overflows to Infinity around the 1740th. With Mag it
+        // produces a precise log10 ≈ 1761 (= 10000 * log10(1.5)).
+        let mods: Vec<_> = (0..10_000).map(|_| perm(vec![mul(1.5)])).collect();
+        let a = FingererAggregate::rebuild(&mods);
+        let expected = (1.5_f64).log10() * 10_000.0;
+        assert!((a.mul_factor.log10 - expected).abs() < 1e-6);
     }
 
     #[test]

--- a/src/game/state.rs
+++ b/src/game/state.rs
@@ -4,6 +4,7 @@ use rand::RngExt;
 use ratatui::layout::Rect;
 use serde::{Deserialize, Serialize};
 
+use crate::bignum::Mag;
 use crate::game::achievement::ACHIEVEMENTS;
 use crate::game::fingerer::{self, FINGERERS};
 use crate::game::modifier::{
@@ -264,13 +265,13 @@ pub struct GameState {
     #[serde(default = "default_save_version")]
     pub version: u32,
     #[serde(default)]
-    pub cuques: f64,
+    pub cuques: Mag,
     #[serde(default)]
     pub total_clicks: u64,
     #[serde(default)]
-    pub lifetime_cuques: f64,
+    pub lifetime_cuques: Mag,
     #[serde(default)]
-    pub best_fps: f64,
+    pub best_fps: Mag,
     /// Lifetime grand total of every powerup caught (Lucky, Frenzy, Buff,
     /// Green Coin). Stays a strict rollup so existing achievements that
     /// gate on it continue to work, and pre-V3 saves whose breakdown was
@@ -377,8 +378,12 @@ pub struct GameState {
     pub active_unlock_id: Option<String>,
     #[serde(skip)]
     pub active_unlock_ticks: u32,
+    /// Per-tick cuque income waiting to be shown via a `+N` auto-particle.
+    /// `Mag` so a late-game FPS that produces astronomical per-tick income
+    /// stays representable; the particle text is rendered through
+    /// `format::big_mag`.
     #[serde(skip)]
-    pub visual_debt: f64,
+    pub visual_debt: Mag,
     #[serde(skip)]
     pub lucky_flash_ticks: u32,
     #[serde(skip)]
@@ -464,7 +469,7 @@ pub struct GameState {
     /// Initialized to the live values on load so the first frame doesn't
     /// look like a count-up from zero.
     #[serde(skip)]
-    pub displayed_cuques: f64,
+    pub displayed_cuques: Mag,
     #[serde(skip)]
     pub displayed_fps: f64,
     /// Brief green flash on the HUD digits when cuques jump UP — golden
@@ -515,10 +520,10 @@ impl Default for GameState {
     fn default() -> Self {
         Self {
             version: crate::save::CURRENT_VERSION,
-            cuques: 0.0,
+            cuques: Mag::ZERO,
             total_clicks: 0,
-            lifetime_cuques: 0.0,
-            best_fps: 0.0,
+            lifetime_cuques: Mag::ZERO,
+            best_fps: Mag::ZERO,
             golden_caught: 0,
             lucky_caught: 0,
             frenzy_caught: 0,
@@ -559,7 +564,7 @@ impl Default for GameState {
             newly_unlocked: Vec::new(),
             active_unlock_id: None,
             active_unlock_ticks: 0,
-            visual_debt: 0.0,
+            visual_debt: Mag::ZERO,
             lucky_flash_ticks: 0,
             achievement_flash_ticks: 0,
             green_coin_flash_ticks: 0,
@@ -575,7 +580,7 @@ impl Default for GameState {
             space_pressed_this_tick: false,
             ticks_since_last_press: u32::MAX,
             space_hold_ticks: 0,
-            displayed_cuques: 0.0,
+            displayed_cuques: Mag::ZERO,
             displayed_fps: 0.0,
             cuques_flash_ticks: 0,
             cuques_spend_flash_ticks: 0,
@@ -724,7 +729,7 @@ impl GameState {
             .enumerate()
             .filter(|(idx, f)| {
                 let owned = self.fingerer_count(f.id);
-                fingerer::visible(*idx, owned, self.lifetime_cuques)
+                fingerer::visible(*idx, owned, self.lifetime_cuques.to_f64())
             })
             .map(|(_, f)| f.id.to_string())
             .collect();
@@ -757,7 +762,8 @@ impl GameState {
         // digits — a single +1 doesn't deserve the green tint, but a
         // Frenzy click (FPS-scaled bonus, often hundreds-to-millions) or
         // any bulk jump does.
-        if power >= 50.0 {
+        let power_threshold = Mag::from_f64(50.0);
+        if power >= power_threshold {
             self.cuques_flash_ticks = HUD_FLASH_TICKS;
         }
         let mut rng = rand::rng();
@@ -782,7 +788,7 @@ impl GameState {
         // Small numbers stay subtle; big ones (Frenzy, Cosmic mults) get a
         // bold ClickBig style so they read as "this matters" against the
         // chatter of auto-particles.
-        let kind = if power >= 50.0 || frenzy_active {
+        let kind = if power >= power_threshold || frenzy_active {
             ParticleKind::ClickBig
         } else {
             ParticleKind::Click
@@ -791,7 +797,7 @@ impl GameState {
             frac_x,
             frac_y,
             life: PARTICLE_LIFE,
-            text: format!("+{}", crate::format::big(power)),
+            text: format!("+{}", crate::format::big_mag(power)),
             kind,
             drift_x,
         });
@@ -851,43 +857,42 @@ impl GameState {
         }
     }
 
-    pub fn click_power(&self) -> f64 {
+    pub fn click_power(&self) -> Mag {
         // Click contributions come from the tree exclusively (old hardcoded
         // ClickMult upgrades are retired). Same fold order as the modifier
         // formula on fingerers: flat first, then (1 + add_percent), then
         // mul_factor.
         let t = &self.tree_aggregate;
-        let base = (1.0 + t.click_flat) * (1.0 + t.click_add) * t.click_mul;
+        let base_scalar = (1.0 + t.click_flat) * (1.0 + t.click_add);
+        let base = Mag::from_f64(base_scalar.max(0.0)).mul(t.click_mul);
         // Per-click Frenzy bonus, FPS-scaled. The legacy `mult: 777.0`
         // on `Buff::ClickFrenzy` is now ignored at click-time (kept on
         // the struct only for V2/V3/V4 save compatibility); each click
-        // during Frenzy adds a flat-or-fps-scaled bonus instead. This
-        // is what keeps an early-game Frenzy (FPS ≈ 0) capped at the
-        // FRENZY_FLAT floor (10 cuques/click) instead of trivializing
-        // the cost ladder via ×777, while a late-game Frenzy still
-        // delivers a ~12× income-rate boost during the buff via the
-        // FRENZY_FPS_SECONDS_PER_CLICK term.
+        // during Frenzy adds a flat-or-fps-scaled bonus instead.
         let frenzy_active = self
             .buffs
             .iter()
             .any(|b| matches!(b, Buff::ClickFrenzy { .. }));
         if frenzy_active {
-            let bonus = (self.fps() * FRENZY_FPS_SECONDS_PER_CLICK).max(FRENZY_FLAT_PER_CLICK);
-            base + bonus
+            let fps = self.fps();
+            let scaled = fps.mul(Mag::from_f64(FRENZY_FPS_SECONDS_PER_CLICK));
+            let floor = Mag::from_f64(FRENZY_FLAT_PER_CLICK);
+            let bonus = if scaled > floor { scaled } else { floor };
+            base.add(bonus)
         } else {
             base
         }
     }
 
-    fn add_cuques(&mut self, amount: f64) {
-        self.cuques += amount;
-        self.lifetime_cuques += amount;
+    fn add_cuques(&mut self, amount: Mag) {
+        self.cuques = self.cuques.add(amount);
+        self.lifetime_cuques = self.lifetime_cuques.add(amount);
     }
 
     /// Dev-build cheat. Bypasses normal flow; not reachable in release builds
     /// because the F-key that triggers it is gated behind `App::debug`.
     pub fn dev_add_cuques(&mut self, amount: f64) {
-        self.add_cuques(amount);
+        self.add_cuques(Mag::from_f64(amount));
         self.cuques_flash_ticks = HUD_FLASH_TICKS;
     }
 
@@ -912,9 +917,9 @@ impl GameState {
     ///
     /// Per-kind cooldown is NOT touched here — it ticks independently
     /// from spawns; a catch just removes the on-screen instance.
-    pub fn catch_powerup(&mut self, spawn_id: u64) -> f64 {
+    pub fn catch_powerup(&mut self, spawn_id: u64) -> Mag {
         let Some(idx) = self.powerups.iter().position(|p| p.spawn_id == spawn_id) else {
-            return 0.0;
+            return Mag::ZERO;
         };
         let p = self.powerups.swap_remove(idx);
         self.golden_caught += 1;
@@ -927,12 +932,16 @@ impl GameState {
                     .powerup_reward_mul
                     .get(PowerupKind::Lucky as usize)
                     .copied()
-                    .unwrap_or(1.0);
-                let r = ((fps * GOLDEN_REWARD_SECONDS).max(GOLDEN_REWARD_FLAT)) * reward_mul;
+                    .unwrap_or(Mag::ONE);
+                let secs = Mag::from_f64(GOLDEN_REWARD_SECONDS);
+                let flat = Mag::from_f64(GOLDEN_REWARD_FLAT);
+                let scaled = fps.mul(secs);
+                let big = if scaled > flat { scaled } else { flat };
+                let r = big.mul(reward_mul);
                 self.add_cuques(r);
                 self.lucky_flash_ticks = LUCKY_FLASH_TICKS;
                 self.cuques_flash_ticks = HUD_FLASH_TICKS;
-                (r, format!("+{}", crate::format::big(r)))
+                (r, format!("+{}", crate::format::big_mag(r)))
             }
             PowerupKind::Frenzy => {
                 self.frenzy_caught += 1;
@@ -941,19 +950,17 @@ impl GameState {
                     .powerup_duration_mul
                     .get(PowerupKind::Frenzy as usize)
                     .copied()
-                    .unwrap_or(1.0);
-                let dur = ((TICK_HZ * 13) as f64 * duration_mul).round() as u32;
-                // `mult: 777.0` is a legacy field — `click_power()` no
-                // longer reads it. The per-click Frenzy bonus is FPS-
-                // scaled via `FRENZY_FPS_SECONDS_PER_CLICK` /
-                // `FRENZY_FLAT_PER_CLICK`. Kept on the struct so V2/V3
-                // saves with this field deserialize cleanly.
+                    .unwrap_or(Mag::ONE);
+                // Duration scales by a Mag — convert at the boundary
+                // and clamp to u32 so the tick counter doesn't wrap.
+                let raw = (TICK_HZ * 13) as f64 * duration_mul.to_f64();
+                let dur = raw.round().clamp(0.0, u32::MAX as f64) as u32;
                 self.buffs.push(Buff::ClickFrenzy {
                     ticks_remaining: dur,
                     initial_ticks: dur,
                     mult: 777.0,
                 });
-                (0.0, "FRENZY!".into())
+                (Mag::ZERO, "FRENZY!".into())
             }
             PowerupKind::Buff => {
                 self.buff_caught += 1;
@@ -962,17 +969,22 @@ impl GameState {
                     .powerup_duration_mul
                     .get(PowerupKind::Buff as usize)
                     .copied()
-                    .unwrap_or(1.0);
+                    .unwrap_or(Mag::ONE);
                 let reward_mul = self
                     .tree_aggregate
                     .powerup_reward_mul
                     .get(PowerupKind::Buff as usize)
                     .copied()
-                    .unwrap_or(1.0);
-                let dur = ((TICK_HZ * 60) as f64 * duration_mul).round() as u32;
+                    .unwrap_or(Mag::ONE);
+                let raw_dur = (TICK_HZ * 60) as f64 * duration_mul.to_f64();
+                let dur = raw_dur.round().clamp(0.0, u32::MAX as f64) as u32;
+                // Persisted MulFactor stays a Mag so a 10k-deep tree
+                // stack's reward_mul doesn't get clamped at f64::MAX
+                // when it's serialized into the fingerer's modifier list.
+                let mul_factor = Mag::from_f64(7.0).mul(reward_mul);
                 let m = Modifier {
                     source: ModifierSource::PurpleCoin,
-                    effects: vec![ModifierEffect::MulFactor(7.0 * reward_mul)],
+                    effects: vec![ModifierEffect::MulFactor(mul_factor)],
                     duration: ModifierDuration::Ticks(dur),
                     created_at_tick: self.total_play_ticks,
                 };
@@ -984,12 +996,19 @@ impl GameState {
                     let pick = FINGERERS[0].id;
                     self.attach_modifier(pick, m);
                 }
-                (0.0, "BOOSTED x7!".into())
+                (Mag::ZERO, "BOOSTED x7!".into())
             }
             PowerupKind::GreenCoin => {
                 self.green_coin_caught += 1;
                 self.green_coin_flash_ticks = GREEN_COIN_FLASH_TICKS;
-                let strength = GREEN_COIN_ADD_PERCENT * self.tree_aggregate.green_coin_strength_mul;
+                // The catch-time amplifier is a Mag, but the resulting
+                // AddPercent we persist is still an `f64`: GreenCoins are
+                // ADDITIVE (sum across modifiers), not multiplicative,
+                // and per-node EffectMul caps keep `green_coin_strength_mul`
+                // at sane sizes for any session length that produces a
+                // meaningful AddPercent before fp precision washes out.
+                let strength_mul = self.tree_aggregate.green_coin_strength_mul.to_f64();
+                let strength = GREEN_COIN_ADD_PERCENT * strength_mul;
                 let m = Modifier {
                     source: ModifierSource::GreenCoin,
                     effects: vec![ModifierEffect::AddPercent(strength)],
@@ -1032,7 +1051,7 @@ impl GameState {
                     // dev.
                     None => "+10% ???".to_string(),
                 };
-                (0.0, label)
+                (Mag::ZERO, label)
             }
         };
         self.particles.push(Particle {
@@ -1046,29 +1065,33 @@ impl GameState {
         reward
     }
 
-    pub fn fps(&self) -> f64 {
+    pub fn fps(&self) -> Mag {
         // Per-fingerer formula:
         //   flat_total = modifier.flat + tree.per_fingerer.flat + tree.all_fingerers.flat
         //   add_total  = modifier.add  + tree.per_fingerer.add  + tree.all_fingerers.add
         //   mul_total  = modifier.mul  * tree.per_fingerer.mul  * tree.all_fingerers.mul
         //   pre  = base * count + flat_total
-        //   post = pre * (1 + add_total) * mul_total
-        // Both aggregates are pre-folded caches — O(1) reads per fingerer.
-        let base: f64 = FINGERERS
-            .iter()
-            .enumerate()
-            .map(|(i, k)| {
-                let count = self.fingerer_count(k.id) as f64;
-                let mod_agg = self.fingerer_aggregate(k.id);
-                let tree = self.tree_aggregate.effective_for_fingerer(i);
-                let flat_total = mod_agg.flat_fps + tree.flat_fps;
-                let add_total = mod_agg.add_percent + tree.add_percent;
-                let mul_total = mod_agg.mul_factor * tree.mul_factor;
-                let pre = k.fps_per_unit * count + flat_total;
-                pre * (1.0 + add_total) * mul_total
-            })
-            .sum();
-        base * self.prestige_mult()
+        //   post = pre * (1 + add_total) * mul_total   (kept as Mag from here)
+        // Multiplicative aggregates live in log-magnitude so the
+        // late-late-game stack (thousands of bought nodes × hundreds of
+        // caught Buffs) can't overflow the way it did with `f64`.
+        let mut total = Mag::ZERO;
+        for (i, k) in FINGERERS.iter().enumerate() {
+            let count = self.fingerer_count(k.id) as f64;
+            let mod_agg = self.fingerer_aggregate(k.id);
+            let tree = self.tree_aggregate.effective_for_fingerer(i);
+            let flat_total = mod_agg.flat_fps + tree.flat_fps;
+            let add_total = mod_agg.add_percent + tree.add_percent;
+            let mul_total = mod_agg.mul_factor.mul(tree.mul_factor);
+            let pre_scalar = (k.fps_per_unit * count + flat_total) * (1.0 + add_total);
+            // `pre_scalar` can theoretically be negative if a stack of
+            // banes outweighs the base; clamp at zero — there's no
+            // honest log10 for a negative quantity and "no contribution"
+            // is the right gameplay reading.
+            let pre_scalar = pre_scalar.max(0.0);
+            total = total.add(Mag::from_f64(pre_scalar).mul(mul_total));
+        }
+        total.mul(self.prestige_mult())
     }
 
     pub fn border_speed(&self) -> u32 {
@@ -1110,28 +1133,53 @@ impl GameState {
         self.purchase_flash_strength = self.purchase_flash_strength.max(strength).clamp(1.0, 3.0);
     }
 
-    pub fn prestige_mult(&self) -> f64 {
+    pub fn prestige_mult(&self) -> Mag {
         let base = 1.0 + 0.01 * self.prestige as f64;
         let t = &self.tree_aggregate;
-        (base + t.prestige_add) * t.prestige_mul
+        // `t.prestige_mul` is `Mag`; the additive `prestige_add` and
+        // base contribution stay `f64` (small, bounded) and fold in
+        // before crossing into log space.
+        Mag::from_f64((base + t.prestige_add).max(0.0)).mul(t.prestige_mul)
     }
 
     pub fn prestige_earned_total(&self) -> u64 {
-        // Guard the only failure modes the math actually has: NaN /
-        // INFINITY from a corrupted `lifetime_cuques`, and negative
-        // values that have no business in a lifetime counter. Past
-        // that, trust the player's number — long-haul legit play can
-        // reach surprisingly high paper counts, and capping the result
-        // would silently truncate their earned progression. The f64-
-        // to-u64 saturation cast only kicks in around `raw > u64::MAX
-        // ≈ 1.8e19` which corresponds to `lifetime_cuques > ~3e44` —
-        // unreachable through any non-corrupted save state.
-        let raw = (self.lifetime_cuques / 1_000_000.0).sqrt().floor();
-        if !raw.is_finite() || raw < 0.0 {
-            0
-        } else {
-            raw as u64
+        // Old formula: `floor(sqrt(lifetime / 1e6))`. Naively rewriting
+        // it in log10 space as `floor(10^((log10(lifetime) - 6) / 2))`
+        // is *algebraically* equal but numerically not — the
+        // `log10 → pow` round-trip can land just below an integer
+        // boundary at ~⅓ of exact tier values, dropping a player's
+        // earned prestige by 1 the moment they upgrade. So: stay in
+        // the original f64 sqrt path for any lifetime that fits in
+        // f64 (which covers any realistic player), and only fall
+        // through to the log-space formula past `log10 ≈ 300` where
+        // f64 starts losing precision.
+        if self.lifetime_cuques.log10 < 6.0 {
+            return 0;
         }
+        if self.lifetime_cuques.log10 < 300.0 {
+            // `Mag::to_f64` is `10^log10` and isn't bit-exact (pow ∘ log
+            // composes two correctly-rounded ops into one slightly-wrong
+            // one), so a tier-boundary value like `25_000_000` arrives
+            // as `24.999_999_999_999_996` and `sqrt.floor()` drops the
+            // earned tier by 1. Add a few-ulp nudge before the floor to
+            // absorb the round-trip noise; legitimate between-tier
+            // values are far enough from an integer that the nudge
+            // doesn't false-positive them upward.
+            let lifetime = self.lifetime_cuques.to_f64();
+            let raw = (lifetime / 1_000_000.0).sqrt();
+            if !raw.is_finite() || raw < 0.0 {
+                return 0;
+            }
+            return (raw + 1e-9).floor() as u64;
+        }
+        // Truly-huge range: stay in log-magnitude space. At this scale
+        // an integer-boundary slop is invisible — the player already
+        // has astronomical prestige.
+        let earned_log10 = (self.lifetime_cuques.log10 - 6.0) * 0.5;
+        Mag {
+            log10: earned_log10,
+        }
+        .floor_u64()
     }
 
     pub fn prestige_available(&self) -> u64 {
@@ -1144,7 +1192,7 @@ impl GameState {
             return false;
         }
         self.prestige = self.prestige_earned_total();
-        self.cuques = 0.0;
+        self.cuques = Mag::ZERO;
         // Don't snap `displayed_cuques` to 0 — let it tween down from
         // its pre-reset value over the next ~1s for a "draining"
         // feel. Same for FPS. The red spend-flash is fired below to
@@ -1167,7 +1215,7 @@ impl GameState {
         self.tree_refund_flash.clear();
         self.tree_edge_anims.clear();
         self.buffs.clear();
-        self.visual_debt = 0.0;
+        self.visual_debt = Mag::ZERO;
         self.particles.clear();
         self.misclick_particles.clear();
         self.powerups.clear();
@@ -1353,9 +1401,9 @@ impl GameState {
         if fps > self.best_fps {
             self.best_fps = fps;
         }
-        let gained = fps * TICK_DT;
+        let gained = fps.mul(Mag::from_f64(TICK_DT));
         self.add_cuques(gained);
-        self.visual_debt += gained;
+        self.visual_debt = self.visual_debt.add(gained);
         self.clench_ticks = self.clench_ticks.saturating_sub(1);
         for p in self.particles.iter_mut() {
             p.life = p.life.saturating_sub(1);
@@ -1405,17 +1453,35 @@ impl GameState {
         // from buying a single fingerer, not worth a tween.
         const SNAP_BELOW: f64 = 5.0;
         let tween = 0.18_f64;
-        let dc = self.cuques - self.displayed_cuques;
-        if dc.abs() < SNAP_BELOW {
+        // Cuques tween: compute the gap in log space. For values past
+        // ~1e15 we just snap to the target — sub-unit precision on the
+        // display tween isn't perceptible up there, and a Mag-space
+        // exponential tween would be visually weird anyway.
+        let cuques_log = self.cuques.log10;
+        let disp_log = self.displayed_cuques.log10;
+        if cuques_log > 15.0 || disp_log > 15.0 {
             self.displayed_cuques = self.cuques;
         } else {
-            self.displayed_cuques += dc * tween;
+            let dc = self.cuques.to_f64() - self.displayed_cuques.to_f64();
+            if dc.abs() < SNAP_BELOW {
+                self.displayed_cuques = self.cuques;
+            } else {
+                self.displayed_cuques = Mag::from_f64(self.displayed_cuques.to_f64() + dc * tween);
+            }
         }
-        let df = fps - self.displayed_fps;
-        if df.abs() < SNAP_BELOW {
-            self.displayed_fps = fps;
+        // FPS tween stays in f64 — `displayed_fps` is f64 (used for HUD
+        // text only, where Mag's display is fine but f64-space tweens
+        // are simpler). For huge FPS we snap.
+        let fps_f64 = fps.to_f64();
+        if fps.log10 > 15.0 {
+            self.displayed_fps = fps_f64;
         } else {
-            self.displayed_fps += df * tween;
+            let df = fps_f64 - self.displayed_fps;
+            if df.abs() < SNAP_BELOW {
+                self.displayed_fps = fps_f64;
+            } else {
+                self.displayed_fps += df * tween;
+            }
         }
 
         self.session_ticks += 1;
@@ -1490,37 +1556,56 @@ impl GameState {
     /// The shown amount is always real cuques that just accrued into
     /// `visual_debt`.
     pub fn spawn_auto_particle(&mut self, frac_x: f32, frac_y: f32) {
-        let amount = self.visual_debt.floor() as u64;
-        if amount == 0 {
+        // The auto-particle shows the WHOLE accrued cuques since the last
+        // particle. Drain visual_debt entirely (no fractional remainder
+        // to subtract — the next tick re-accrues from FPS).
+        if self.visual_debt.log10 < 0.0 {
+            // Less than 1 cuque accrued; skip the particle.
             return;
         }
-        self.visual_debt -= amount as f64;
+        let amount = self.visual_debt;
+        self.visual_debt = Mag::ZERO;
         let drift_x = rand::rng().random_range(-0.008_f32..=0.008);
         self.particles.push(Particle {
             frac_x,
             frac_y,
             life: PARTICLE_LIFE,
-            text: format!("+{}", crate::format::big(amount as f64)),
+            text: format!("+{}", crate::format::big_mag(amount)),
             kind: ParticleKind::Auto,
             drift_x,
         });
     }
 
-    pub fn cost(&self, idx: usize) -> f64 {
+    pub fn cost(&self, idx: usize) -> Mag {
         let k = &FINGERERS[idx];
         // Floor the result so the cost ALWAYS equals what `format::big`
         // shows the player. The price formula scales by 1.15× per owned
         // unit and produces fractional cuques (e.g. 15 × 1.15⁶ = 34.69).
         // Tree cost-mul (procgen `CostMul` primitives) folds in here so
         // discounts/inflation behave the same for display, gate, and spend.
-        let raw = k.base_cost * k.cost_scale.powi(self.fingerer_count_idx(idx) as i32);
+        //
+        // `raw` is computed in log10 space (`log10(b * s^n) = log10(b) + n*log10(s)`)
+        // so fingerer counts well past the f64 overflow point still
+        // produce a finite Mag price. The tree's per-fingerer cost_mul
+        // (a Mag) folds in via multiplication = addition of logs.
+        let n = self.fingerer_count_idx(idx) as f64;
+        let log_raw = k.base_cost.log10() + n * k.cost_scale.log10();
+        let raw = Mag { log10: log_raw };
         let cost_mul = self
             .tree_aggregate
             .per_fingerer
             .get(idx)
             .map(|c| c.cost_mul)
-            .unwrap_or(1.0);
-        (raw * cost_mul).floor().max(1.0)
+            .unwrap_or(Mag::ONE);
+        let combined = raw.mul(cost_mul);
+        // Floor + clamp-to-1 for the small-number range; once we're in
+        // truly-big territory the player can't perceive sub-unit
+        // precision anyway.
+        if combined.log10 < 18.0 {
+            Mag::from_f64(combined.to_f64().floor().max(1.0))
+        } else {
+            combined
+        }
     }
 
     /// Cuques the player can ACTUALLY spend right now: the lesser of real
@@ -1540,8 +1625,21 @@ impl GameState {
     /// equally binding: row turns green only when the visible counter
     /// AND the underlying balance both reach the cost; click succeeds
     /// only when both still hold. No overspend, no visual lie.
-    pub fn affordable_cuques(&self) -> f64 {
-        self.cuques.min(self.displayed_cuques.floor())
+    pub fn affordable_cuques(&self) -> Mag {
+        // `Mag` lacks `.floor()` in log space; mirror the original
+        // f64 behavior by flooring the displayed counter at its f64
+        // boundary (the player can never perceive sub-unit precision
+        // up there anyway).
+        let disp_floor = if self.displayed_cuques.log10 < 18.0 {
+            Mag::from_f64(self.displayed_cuques.to_f64().floor())
+        } else {
+            self.displayed_cuques
+        };
+        if self.cuques < disp_floor {
+            self.cuques
+        } else {
+            disp_floor
+        }
     }
 
     pub fn can_buy(&self, idx: usize) -> bool {
@@ -1561,7 +1659,7 @@ impl GameState {
         if self.affordable_cuques() >= c
             && let Some(f) = FINGERERS.get(idx)
         {
-            self.cuques -= c;
+            self.cuques = self.cuques.saturating_sub(c);
             self.fingerers_state
                 .entry(f.id.to_string())
                 .or_default()
@@ -1716,7 +1814,7 @@ impl GameState {
         let neighbors = node::neighbors_of(lot);
         let was_reachable: [bool; 8] = std::array::from_fn(|i| self.tree_reachable(neighbors[i]));
 
-        self.cuques -= node.cost;
+        self.cuques = self.cuques.saturating_sub(node.cost);
         self.tree.bought.insert(lot);
         self.tree.last_bought = Some(lot);
         self.tree_aggregate.fold_in_node(&node);
@@ -1803,9 +1901,9 @@ impl GameState {
     /// `cost * TREE_REFUND_FRACTION` — the remaining fraction is the
     /// exploration tax (see the constant for rationale). Connectivity
     /// guard: rejects if it would orphan any other owned node.
-    pub fn refund_tree_node(&mut self, lot: TreeCoord) -> f64 {
+    pub fn refund_tree_node(&mut self, lot: TreeCoord) -> Mag {
         if !self.can_refund_tree_node(lot) {
-            return 0.0;
+            return Mag::ZERO;
         }
         let Some(node) = node::node_at(lot.x, lot.y) else {
             // Ghost lot in `bought` (e.g. survived a procgen change that
@@ -1816,15 +1914,15 @@ impl GameState {
             if self.tree.last_bought == Some(lot) {
                 self.tree.last_bought = None;
             }
-            return 0.0;
+            return Mag::ZERO;
         };
         self.tree.bought.remove(&lot);
         if self.tree.last_bought == Some(lot) {
             self.tree.last_bought = None;
         }
         self.tree_aggregate.fold_out_node(&node);
-        let refunded = (node.cost * TREE_REFUND_FRACTION).floor();
-        self.cuques += refunded;
+        let refunded = node.cost.mul(Mag::from_f64(TREE_REFUND_FRACTION));
+        self.cuques = self.cuques.add(refunded);
         // Red pulse on the now-unowned lot. The lot still renders (as an
         // unowned reachable/dotted box depending on connectivity), so the
         // flash decays visibly there.
@@ -1885,11 +1983,40 @@ mod tests {
     }
 
     #[test]
+    fn prestige_earned_matches_legacy_sqrt_at_tier_boundaries() {
+        // Old formula was `floor(sqrt(lifetime / 1e6))`. The naive
+        // log-space rewrite `floor(10^((log10(lifetime) - 6) / 2))`
+        // rounds differently at ~⅓ of integer-tier boundaries, dropping
+        // a player's earned prestige by 1 on next launch. Pin the
+        // boundary values that used to misbehave so the regression
+        // can't slip back in.
+        // Each value is checked against the legacy `floor(sqrt(x/1e6))`.
+        let cases: &[(f64, u64)] = &[
+            (0.0, 0),
+            (999_999.0, 0),          // just under 1 tier
+            (1_000_000.0, 1),        // exactly 1 tier
+            (4_000_000.0, 2),        // 2 tiers
+            (25_000_000.0, 5),       // 5 tiers — regression case
+            (81_000_000.0, 9),       // 9 tiers — regression case
+            (1_000_000_000.0, 31),   // sqrt(1000) ≈ 31.62
+            (10_000_000_000.0, 100), // sqrt(10000) = 100
+            (1e18, 1_000_000),       // sqrt(1e12) = 1e6
+        ];
+        for &(lifetime, expected) in cases {
+            let s = GameState {
+                lifetime_cuques: Mag::from_f64(lifetime),
+                ..GameState::default()
+            };
+            assert_eq!(s.prestige_earned_total(), expected, "lifetime={lifetime}");
+        }
+    }
+
+    #[test]
     fn save_roundtrip_is_stable_through_json() {
         // Serialize → deserialize → get the same state back. Catches any
         // accidental rename that would make saves non-idempotent.
         let mut state = GameState {
-            cuques: 1234.5,
+            cuques: Mag::from_f64(1234.5),
             total_clicks: 99,
             fingerers_state: [("index_finger".to_string(), fs_with_count(7))]
                 .into_iter()
@@ -1903,7 +2030,7 @@ mod tests {
         let roundtripped: GameState = serde_json::from_str(&json).expect("deserialize");
         let m = roundtripped.migrate_runtime();
 
-        assert_eq!(m.cuques, 1234.5);
+        assert!((m.cuques.to_f64() - 1234.5).abs() < 1e-9);
         assert_eq!(m.total_clicks, 99);
         assert_eq!(m.fingerer_count("index_finger"), 7);
         assert!(m.tree.bought.contains(&TreeCoord::new(2, -1)));
@@ -2002,8 +2129,8 @@ mod tests {
         // counter on the HUD) — a default-constructed test state has
         // displayed=0 and would otherwise reject every buy.
         let mut s = GameState {
-            cuques: 1_000_000.0,
-            displayed_cuques: 1_000_000.0,
+            cuques: Mag::from_f64(1_000_000.0),
+            displayed_cuques: Mag::from_f64(1_000_000.0),
             ..Default::default()
         };
         s.buy(0);
@@ -2011,8 +2138,8 @@ mod tests {
         assert!((1.0..=3.0).contains(&single));
 
         let mut s = GameState {
-            cuques: 1_000_000.0,
-            displayed_cuques: 1_000_000.0,
+            cuques: Mag::from_f64(1_000_000.0),
+            displayed_cuques: Mag::from_f64(1_000_000.0),
             ..Default::default()
         };
         s.buy_n(0, 50);
@@ -2034,7 +2161,7 @@ mod tests {
         let spec = node::node_at(0, 0).expect("anchor always exists");
         assert!(spec.is_anchor);
         assert!(spec.primitives.is_empty());
-        assert_eq!(spec.cost, 0.0);
+        assert_eq!(spec.cost, Mag::ZERO);
     }
 
     #[test]
@@ -2042,8 +2169,8 @@ mod tests {
         // Origin is auto-owned in Default, so any attempt to buy it
         // returns None ("already owned"). Cuques aren't spent.
         let mut s = GameState {
-            cuques: 1_000_000.0,
-            displayed_cuques: 1_000_000.0,
+            cuques: Mag::from_f64(1_000_000.0),
+            displayed_cuques: Mag::from_f64(1_000_000.0),
             ..Default::default()
         };
         let pre = s.cuques;
@@ -2057,12 +2184,12 @@ mod tests {
     fn refund_origin_is_rejected() {
         // Origin is the anchor — non-refundable regardless of state.
         let mut s = GameState {
-            cuques: 1_000_000.0,
-            displayed_cuques: 1_000_000.0,
+            cuques: Mag::from_f64(1_000_000.0),
+            displayed_cuques: Mag::from_f64(1_000_000.0),
             ..Default::default()
         };
         let pre = s.cuques;
-        assert_eq!(s.refund_tree_node(TreeCoord::ORIGIN), 0.0);
+        assert_eq!(s.refund_tree_node(TreeCoord::ORIGIN), Mag::ZERO);
         assert!(s.tree.bought.contains(&TreeCoord::ORIGIN));
         assert_eq!(s.cuques, pre, "no cuques returned on a refund-rejection");
     }
@@ -2072,8 +2199,8 @@ mod tests {
         // The exploration tax means buy + refund is a net loss. Without
         // this, the player could spam every node combination for free.
         let mut s = GameState {
-            cuques: 1_000_000.0,
-            displayed_cuques: 1_000_000.0,
+            cuques: Mag::from_f64(1_000_000.0),
+            displayed_cuques: Mag::from_f64(1_000_000.0),
             ..Default::default()
         };
         let pre = s.cuques;
@@ -2089,12 +2216,16 @@ mod tests {
             .buy_tree_node(neighbor)
             .expect("affordable with 1M cuques");
         let after_buy = s.cuques;
-        assert!((after_buy - (pre - n_node.cost)).abs() < 1e-6);
+        // `pre - n_node.cost` in Mag-space, compared against `after_buy`.
+        // Both should be within float-rounding distance; compare in
+        // log10 space.
+        let expected_after = pre.saturating_sub(n_node.cost);
+        assert!((after_buy.log10 - expected_after.log10).abs() < 1e-6);
 
         // Refund: gets back fraction * cost, loses (1 - fraction) * cost.
         let refunded = s.refund_tree_node(neighbor);
-        let expected = (n_node.cost * TREE_REFUND_FRACTION).floor();
-        assert!((refunded - expected).abs() < 1e-6);
+        let expected = n_node.cost.mul(Mag::from_f64(TREE_REFUND_FRACTION));
+        assert!((refunded.log10 - expected.log10).abs() < 1e-6);
         let after_refund = s.cuques;
         assert!(after_refund > after_buy);
         assert!(
@@ -2124,11 +2255,11 @@ mod tests {
         // J5 contract: a freshly-loaded save shows the live counters at full
         // value, not "tweening up from zero".
         let s = GameState {
-            cuques: 5_000.0,
+            cuques: Mag::from_f64(5_000.0),
             ..Default::default()
         };
         let m = s.migrate_runtime();
-        assert_eq!(m.displayed_cuques, 5_000.0);
+        assert_eq!(m.displayed_cuques, Mag::from_f64(5_000.0));
         // displayed_fps starts at 0 and converges over the first few ticks
         // (otherwise we'd snap-show the FPS before any tick has run).
         assert_eq!(m.displayed_fps, 0.0);
@@ -2164,7 +2295,7 @@ mod tests {
     fn timed_mul(mult: f64, ticks: u32) -> Modifier {
         Modifier {
             source: ModifierSource::PurpleCoin,
-            effects: vec![ModifierEffect::MulFactor(mult)],
+            effects: vec![ModifierEffect::MulFactor(Mag::from_f64(mult))],
             duration: ModifierDuration::Ticks(ticks),
             created_at_tick: 0,
         }
@@ -2254,7 +2385,7 @@ mod tests {
         s.tick();
         let st = s.fingerers_state.get("index_finger").unwrap();
         assert_eq!(st.modifiers.len(), 0);
-        assert!((st.aggregate.mul_factor - 1.0).abs() < 1e-9);
+        assert!((st.aggregate.mul_factor.to_f64() - 1.0).abs() < 1e-9);
     }
 
     #[test]
@@ -2281,7 +2412,7 @@ mod tests {
         // survive. Otherwise a prestiged player would carry +N% on tier-1
         // forever.
         let mut s = GameState {
-            lifetime_cuques: 1_000_000_000.0,
+            lifetime_cuques: Mag::from_f64(1_000_000_000.0),
             ..Default::default()
         };
         s.fingerers_state
@@ -2306,8 +2437,9 @@ mod tests {
         boosted.attach_modifier("index_finger", perm_add_percent(0.10));
         let boosted_fps = boosted.fps();
 
-        assert!(bare_fps > 0.0);
-        assert!((boosted_fps - bare_fps * 1.10).abs() < 1e-9);
+        assert!(!bare_fps.is_zero());
+        let expected = bare_fps.mul(Mag::from_f64(1.10));
+        assert!((boosted_fps.log10 - expected.log10).abs() < 1e-9);
     }
 
     #[test]
@@ -2403,7 +2535,7 @@ mod tests {
     #[test]
     fn attach_modifier_random_visible_can_pick_unowned_when_lifetime_unlocks_it() {
         let mut s = GameState {
-            lifetime_cuques: 60.0,
+            lifetime_cuques: Mag::from_f64(60.0),
             ..Default::default()
         };
         let m = perm_add_percent(0.10);
@@ -2413,7 +2545,8 @@ mod tests {
             .iter()
             .enumerate()
             .filter(|(idx, f)| {
-                fingerer::visible(*idx, 0, s.lifetime_cuques) && (*idx == 0 || f.id == "whole_hand")
+                fingerer::visible(*idx, 0, s.lifetime_cuques.to_f64())
+                    && (*idx == 0 || f.id == "whole_hand")
             })
             .map(|(_, f)| f.id)
             .collect();
@@ -2423,7 +2556,7 @@ mod tests {
     #[test]
     fn catch_powerup_returns_zero_when_id_unknown() {
         let mut s = GameState::default();
-        assert_eq!(s.catch_powerup(9_999), 0.0);
+        assert_eq!(s.catch_powerup(9_999), Mag::ZERO);
     }
 
     #[test]
@@ -2468,7 +2601,7 @@ mod tests {
     #[test]
     fn prestige_reset_clears_powerup_state() {
         let mut s = GameState {
-            lifetime_cuques: 1_000_000_000.0,
+            lifetime_cuques: Mag::from_f64(1_000_000_000.0),
             ..Default::default()
         };
         s.fingerers_state
@@ -2511,7 +2644,7 @@ mod tests {
         }
         let st = s.fingerers_state.get("index_finger").unwrap();
         assert_eq!(st.modifiers.len(), 2);
-        assert!((st.aggregate.mul_factor - 49.0).abs() < 1e-9);
+        assert!((st.aggregate.mul_factor.to_f64() - 49.0).abs() < 1e-9);
     }
 
     #[test]
@@ -2583,16 +2716,16 @@ mod tests {
             s.tick();
         }
         assert!(
-            s.cuques < 2_000.0,
+            s.cuques < Mag::from_f64(2_000.0),
             "early-game Frenzy must not blow past ~1k cuques; got {}",
-            s.cuques
+            crate::format::big_mag(s.cuques)
         );
         // Sanity: the buff did boost something (more than zero clicks
         // worth of base power = 1).
         assert!(
-            s.cuques > clicks as f64,
+            s.cuques > Mag::from_f64(clicks as f64),
             "Frenzy should still meaningfully boost clicks; got {} from {} clicks",
-            s.cuques,
+            crate::format::big_mag(s.cuques),
             clicks
         );
     }
@@ -2613,8 +2746,9 @@ mod tests {
             .insert("whole_hand".into(), fs_with_count(2000));
         let fps = s.fps();
         assert!(
-            fps > 100.0,
-            "test setup expected fps>100, got {fps} — adjust the count if fingerer base changed"
+            fps > Mag::from_f64(100.0),
+            "test setup expected fps>100, got {} — adjust the count if fingerer base changed",
+            crate::format::big_mag(fps)
         );
         // Activate Frenzy and click once.
         s.buffs.push(Buff::ClickFrenzy {
@@ -2625,14 +2759,19 @@ mod tests {
         let cuques_before = s.cuques;
         let biscuit = r(0, 0, 40, 20);
         s.click((20, 10), biscuit);
-        let yield_per_click = s.cuques - cuques_before;
+        let yield_per_click = s.cuques.saturating_sub(cuques_before);
         // Should be roughly fps * 5.0 + base click_power (no upgrades = 1).
-        let expected = fps * FRENZY_FPS_SECONDS_PER_CLICK + 1.0;
+        let expected = fps
+            .mul(Mag::from_f64(FRENZY_FPS_SECONDS_PER_CLICK))
+            .add(Mag::ONE);
         // Floor of FRENZY_FLAT_PER_CLICK doesn't kick in here because
         // fps * 5 > 10.
         assert!(
-            (yield_per_click - expected).abs() < expected * 0.01,
-            "expected ~{expected}/click at fps={fps}, got {yield_per_click}"
+            (yield_per_click.log10 - expected.log10).abs() < 0.01,
+            "expected ~{}/click at fps={}, got {}",
+            crate::format::big_mag(expected),
+            crate::format::big_mag(fps),
+            crate::format::big_mag(yield_per_click)
         );
     }
 
@@ -2642,7 +2781,7 @@ mod tests {
         // just the base × upgrades — no FPS-scaled bonus added.
         let s = GameState::default();
         // No upgrades, no Frenzy.
-        assert_eq!(s.click_power(), 1.0);
+        assert_eq!(s.click_power(), Mag::ONE);
     }
 
     #[test]

--- a/src/game/tree/aggregate.rs
+++ b/src/game/tree/aggregate.rs
@@ -8,6 +8,7 @@
 
 use std::collections::HashSet;
 
+use crate::bignum::Mag;
 use crate::game::fingerer::FINGERERS;
 use crate::game::powerup::N_KINDS;
 use crate::game::tree::coord::TreeCoord;
@@ -17,14 +18,20 @@ use crate::game::tree::primitive::{Op, Primitive, Target};
 /// Per-fingerer contribution from the tree. Mirrors `FingererAggregate`
 /// (additive percent sums, mul factor multiplies, flat sums) so the FPS
 /// formula combines tree + modifier contributions symmetrically.
+///
+/// Multiplicative fields live in `Mag` (log-magnitude) because they
+/// compound across hundreds-to-thousands of bought nodes; the original
+/// `f64` storage produced `Infinity` in long-haul play. Additive fields
+/// (`flat_fps`, `add_percent`) stay `f64` — they don't compound and
+/// per-node values stay tiny.
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FingererTreeContrib {
     pub flat_fps: f64,
     pub add_percent: f64,
-    pub mul_factor: f64,
+    pub mul_factor: Mag,
     /// Multiplicative on the buy cost of this fingerer (`< 1.0` discount,
     /// `> 1.0` inflation). Used by `GameState::cost`.
-    pub cost_mul: f64,
+    pub cost_mul: Mag,
 }
 
 impl Default for FingererTreeContrib {
@@ -32,14 +39,21 @@ impl Default for FingererTreeContrib {
         Self {
             flat_fps: 0.0,
             add_percent: 0.0,
-            mul_factor: 1.0,
-            cost_mul: 1.0,
+            mul_factor: Mag::ONE,
+            cost_mul: Mag::ONE,
         }
     }
 }
 
 /// All of the tree's contributions, pre-folded into a single struct for
 /// O(1) reads on the hot paths.
+///
+/// All multiplicative fields are `Mag` so multi-thousand-node stacks
+/// can't overflow. The few small-magnitude additive fields stay `f64`
+/// because they don't compound. `powerup_spawn_mul` also stays `f64`
+/// because its consumer (`sim::next_cooldown`) computes
+/// `base / mul_f64` directly and we'd just round-trip through `f64`
+/// anyway.
 #[derive(Clone, Debug)]
 pub struct TreeAggregate {
     /// Per-fingerer contributions, indexed by `FINGERERS` catalog position.
@@ -48,22 +62,29 @@ pub struct TreeAggregate {
     /// fingerer's per-tier output. Stack on top of per-fingerer.
     pub all_fingerers_flat: f64,
     pub all_fingerers_add: f64,
-    pub all_fingerers_mul: f64,
+    pub all_fingerers_mul: Mag,
     /// Click contributions.
     pub click_add: f64,
-    pub click_mul: f64,
+    pub click_mul: Mag,
     pub click_flat: f64,
     /// Prestige multiplier extensions (applied on top of the base
     /// prestige formula).
     pub prestige_add: f64,
-    pub prestige_mul: f64,
-    /// Per-powerup-kind multipliers, indexed by `PowerupKind as usize`.
+    pub prestige_mul: Mag,
+    /// Per-powerup-kind spawn-rate multiplier. `f64` because the only
+    /// consumer (`sim::next_cooldown`) needs the raw value as a divisor
+    /// and the per-node cap (×1.005) keeps any realistic stack inside
+    /// `f64` range.
     pub powerup_spawn_mul: [f64; N_KINDS],
-    pub powerup_reward_mul: [f64; N_KINDS],
-    pub powerup_duration_mul: [f64; N_KINDS],
+    /// Per-powerup-kind reward multiplier. `Mag` because this stage was
+    /// the headline overflow path: `powerup_reward_mul[Buff]` scales the
+    /// 7× MulFactor that gets persisted on a fingerer every Buff catch,
+    /// and 10k+ deep tree stacks would otherwise blow past `f64`.
+    pub powerup_reward_mul: [Mag; N_KINDS],
+    pub powerup_duration_mul: [Mag; N_KINDS],
     /// Green Coin AddPercent strength multiplier (the base +10% becomes
     /// +10% * green_coin_strength_mul on catch).
-    pub green_coin_strength_mul: f64,
+    pub green_coin_strength_mul: Mag,
 }
 
 impl Default for TreeAggregate {
@@ -72,16 +93,16 @@ impl Default for TreeAggregate {
             per_fingerer: vec![FingererTreeContrib::default(); FINGERERS.len()],
             all_fingerers_flat: 0.0,
             all_fingerers_add: 0.0,
-            all_fingerers_mul: 1.0,
+            all_fingerers_mul: Mag::ONE,
             click_add: 0.0,
-            click_mul: 1.0,
+            click_mul: Mag::ONE,
             click_flat: 0.0,
             prestige_add: 0.0,
-            prestige_mul: 1.0,
+            prestige_mul: Mag::ONE,
             powerup_spawn_mul: [1.0; N_KINDS],
-            powerup_reward_mul: [1.0; N_KINDS],
-            powerup_duration_mul: [1.0; N_KINDS],
-            green_coin_strength_mul: 1.0,
+            powerup_reward_mul: [Mag::ONE; N_KINDS],
+            powerup_duration_mul: [Mag::ONE; N_KINDS],
+            green_coin_strength_mul: Mag::ONE,
         }
     }
 }
@@ -100,16 +121,16 @@ impl TreeAggregate {
         }
         self.all_fingerers_flat = 0.0;
         self.all_fingerers_add = 0.0;
-        self.all_fingerers_mul = 1.0;
+        self.all_fingerers_mul = Mag::ONE;
         self.click_add = 0.0;
-        self.click_mul = 1.0;
+        self.click_mul = Mag::ONE;
         self.click_flat = 0.0;
         self.prestige_add = 0.0;
-        self.prestige_mul = 1.0;
+        self.prestige_mul = Mag::ONE;
         self.powerup_spawn_mul = [1.0; N_KINDS];
-        self.powerup_reward_mul = [1.0; N_KINDS];
-        self.powerup_duration_mul = [1.0; N_KINDS];
-        self.green_coin_strength_mul = 1.0;
+        self.powerup_reward_mul = [Mag::ONE; N_KINDS];
+        self.powerup_duration_mul = [Mag::ONE; N_KINDS];
+        self.green_coin_strength_mul = Mag::ONE;
     }
 
     /// Rebuild the aggregate from scratch by regenerating each owned node
@@ -151,14 +172,26 @@ impl TreeAggregate {
         FingererTreeContrib {
             flat_fps: base.flat_fps + self.all_fingerers_flat,
             add_percent: base.add_percent + self.all_fingerers_add,
-            mul_factor: base.mul_factor * self.all_fingerers_mul,
+            mul_factor: base.mul_factor.mul(self.all_fingerers_mul),
             cost_mul: base.cost_mul,
         }
     }
 }
 
+/// Apply (`add == true`) or undo (`add == false`) a single primitive's
+/// contribution. Multiplicative primitives compose via `Mag` so the
+/// running product stays representable no matter how many nodes the
+/// player buys.
 fn fold_primitive(agg: &mut TreeAggregate, p: Primitive, add: bool) {
     let sign = if add { 1.0 } else { -1.0 };
+    let mag = Mag::from_f64(p.magnitude);
+    let apply_mul = |slot: &mut Mag, m: Mag| {
+        if add {
+            *slot = slot.mul(m);
+        } else if !m.is_zero() {
+            *slot = slot.div(m);
+        }
+    };
     match (p.op, p.target) {
         // --- Per-fingerer ---
         (Op::AddPercent, Target::Fingerer(i)) => {
@@ -168,11 +201,7 @@ fn fold_primitive(agg: &mut TreeAggregate, p: Primitive, add: bool) {
         }
         (Op::MulFactor, Target::Fingerer(i)) => {
             if let Some(c) = agg.per_fingerer.get_mut(i as usize) {
-                if add {
-                    c.mul_factor *= p.magnitude;
-                } else if p.magnitude != 0.0 {
-                    c.mul_factor /= p.magnitude;
-                }
+                apply_mul(&mut c.mul_factor, mag);
             }
         }
         (Op::FlatAdd, Target::Fingerer(i)) => {
@@ -182,42 +211,20 @@ fn fold_primitive(agg: &mut TreeAggregate, p: Primitive, add: bool) {
         }
         (Op::CostMul, Target::Fingerer(i)) => {
             if let Some(c) = agg.per_fingerer.get_mut(i as usize) {
-                if add {
-                    c.cost_mul *= p.magnitude;
-                } else if p.magnitude != 0.0 {
-                    c.cost_mul /= p.magnitude;
-                }
+                apply_mul(&mut c.cost_mul, mag);
             }
         }
         // --- All fingerers ---
         (Op::AddPercent, Target::AllFingerers) => agg.all_fingerers_add += sign * p.magnitude,
-        (Op::MulFactor, Target::AllFingerers) => {
-            if add {
-                agg.all_fingerers_mul *= p.magnitude;
-            } else if p.magnitude != 0.0 {
-                agg.all_fingerers_mul /= p.magnitude;
-            }
-        }
+        (Op::MulFactor, Target::AllFingerers) => apply_mul(&mut agg.all_fingerers_mul, mag),
         (Op::FlatAdd, Target::AllFingerers) => agg.all_fingerers_flat += sign * p.magnitude,
         // --- Click ---
         (Op::AddPercent, Target::Click) => agg.click_add += sign * p.magnitude,
-        (Op::MulFactor, Target::Click) => {
-            if add {
-                agg.click_mul *= p.magnitude;
-            } else if p.magnitude != 0.0 {
-                agg.click_mul /= p.magnitude;
-            }
-        }
+        (Op::MulFactor, Target::Click) => apply_mul(&mut agg.click_mul, mag),
         (Op::FlatAdd, Target::Click) => agg.click_flat += sign * p.magnitude,
         // --- Prestige ---
         (Op::AddPercent, Target::Prestige) => agg.prestige_add += sign * p.magnitude,
-        (Op::MulFactor, Target::Prestige) => {
-            if add {
-                agg.prestige_mul *= p.magnitude;
-            } else if p.magnitude != 0.0 {
-                agg.prestige_mul /= p.magnitude;
-            }
-        }
+        (Op::MulFactor, Target::Prestige) => apply_mul(&mut agg.prestige_mul, mag),
         // --- Powerup spawn / reward / duration ---
         (Op::SpawnRateMul, Target::PowerupSpawn(k)) => {
             let i = k as usize;
@@ -228,28 +235,14 @@ fn fold_primitive(agg: &mut TreeAggregate, p: Primitive, add: bool) {
             }
         }
         (Op::EffectMul, Target::PowerupReward(k)) => {
-            let i = k as usize;
-            if add {
-                agg.powerup_reward_mul[i] *= p.magnitude;
-            } else if p.magnitude != 0.0 {
-                agg.powerup_reward_mul[i] /= p.magnitude;
-            }
+            apply_mul(&mut agg.powerup_reward_mul[k as usize], mag);
         }
         (Op::EffectMul, Target::PowerupDuration(k)) => {
-            let i = k as usize;
-            if add {
-                agg.powerup_duration_mul[i] *= p.magnitude;
-            } else if p.magnitude != 0.0 {
-                agg.powerup_duration_mul[i] /= p.magnitude;
-            }
+            apply_mul(&mut agg.powerup_duration_mul[k as usize], mag);
         }
         // --- Green Coin strength ---
         (Op::EffectMul, Target::GreenCoinStrength) => {
-            if add {
-                agg.green_coin_strength_mul *= p.magnitude;
-            } else if p.magnitude != 0.0 {
-                agg.green_coin_strength_mul /= p.magnitude;
-            }
+            apply_mul(&mut agg.green_coin_strength_mul, mag);
         }
         // Op/Target combinations the procgen never produces — fail loud
         // in dev so a future generation bug or new enum variant can't
@@ -285,14 +278,17 @@ mod tests {
         for c in &a.per_fingerer {
             assert_eq!(c.flat_fps, 0.0);
             assert_eq!(c.add_percent, 0.0);
-            assert_eq!(c.mul_factor, 1.0);
-            assert_eq!(c.cost_mul, 1.0);
+            assert_eq!(c.mul_factor, Mag::ONE);
+            assert_eq!(c.cost_mul, Mag::ONE);
         }
-        assert_eq!(a.all_fingerers_mul, 1.0);
-        assert_eq!(a.click_mul, 1.0);
-        assert_eq!(a.prestige_mul, 1.0);
+        assert_eq!(a.all_fingerers_mul, Mag::ONE);
+        assert_eq!(a.click_mul, Mag::ONE);
+        assert_eq!(a.prestige_mul, Mag::ONE);
         for v in a.powerup_spawn_mul {
             assert_eq!(v, 1.0);
+        }
+        for v in a.powerup_reward_mul {
+            assert_eq!(v, Mag::ONE);
         }
     }
 
@@ -310,11 +306,9 @@ mod tests {
         for &pp in &prims {
             fold_primitive(&mut a, pp, false);
         }
-        // Folding in then out should produce a state equal to default
-        // within float error.
         assert!((a.per_fingerer[0].add_percent).abs() < 1e-12);
-        assert!((a.click_mul - 1.0).abs() < 1e-12);
-        assert!((a.green_coin_strength_mul - 1.0).abs() < 1e-12);
+        assert!((a.click_mul.to_f64() - 1.0).abs() < 1e-12);
+        assert!((a.green_coin_strength_mul.to_f64() - 1.0).abs() < 1e-12);
     }
 
     #[test]
@@ -330,7 +324,20 @@ mod tests {
         let mut a = TreeAggregate::default();
         fold_primitive(&mut a, p(Op::MulFactor, Target::Click, 2.0), true);
         fold_primitive(&mut a, p(Op::MulFactor, Target::Click, 3.0), true);
-        assert!((a.click_mul - 6.0).abs() < 1e-12);
+        assert!((a.click_mul.to_f64() - 6.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn mul_factor_stack_is_truly_unbounded() {
+        // The whole point of switching to `Mag`: a stack of 100k nodes
+        // each contributing ×1.005 used to overflow `f64` to `Infinity`.
+        // Now it stays representable and the log10 is exact.
+        let mut a = TreeAggregate::default();
+        for _ in 0..100_000 {
+            fold_primitive(&mut a, p(Op::MulFactor, Target::Click, 1.005), true);
+        }
+        let expected_log10 = (1.005_f64).log10() * 100_000.0;
+        assert!((a.click_mul.log10 - expected_log10).abs() < 1e-6);
     }
 
     #[test]
@@ -348,16 +355,11 @@ mod tests {
         // Pre-pollute then rebuild from empty.
         fold_primitive(&mut a, p(Op::MulFactor, Target::Click, 5.0), true);
         a.rebuild_from_bought(&HashSet::new());
-        assert_eq!(a.click_mul, 1.0);
+        assert_eq!(a.click_mul, Mag::ONE);
     }
 
     #[test]
     fn rebuild_with_only_anchor_is_identity() {
-        // The origin (anchor) carries NO primitives — it's the cuque
-        // sprite, always-active, with zero gameplay effect. So an
-        // aggregate rebuilt with just the anchor owned should equal the
-        // identity aggregate. Confirms anchor + non-anchor rebuilds
-        // compose correctly.
         let mut bought = HashSet::new();
         bought.insert(TreeCoord::ORIGIN);
         let mut a = TreeAggregate::default();
@@ -365,11 +367,11 @@ mod tests {
         for c in &a.per_fingerer {
             assert_eq!(c.add_percent, 0.0);
             assert_eq!(c.flat_fps, 0.0);
-            assert!((c.mul_factor - 1.0).abs() < 1e-12);
-            assert!((c.cost_mul - 1.0).abs() < 1e-12);
+            assert_eq!(c.mul_factor, Mag::ONE);
+            assert_eq!(c.cost_mul, Mag::ONE);
         }
-        assert!((a.click_mul - 1.0).abs() < 1e-12);
-        assert!((a.all_fingerers_mul - 1.0).abs() < 1e-12);
-        assert!((a.prestige_mul - 1.0).abs() < 1e-12);
+        assert_eq!(a.click_mul, Mag::ONE);
+        assert_eq!(a.all_fingerers_mul, Mag::ONE);
+        assert_eq!(a.prestige_mul, Mag::ONE);
     }
 }

--- a/src/game/tree/naming.rs
+++ b/src/game/tree/naming.rs
@@ -917,25 +917,45 @@ fn fingerer_noun_pool(idx: usize) -> &'static [&'static str] {
 /// numbers are locale-neutral; only the connector ("to", "cost on", …)
 /// and the target label flip per locale.
 pub fn primitive_blurb(p: Primitive) -> String {
+    use crate::format::{flat_magnitude, mul_magnitude, percent_magnitude};
     let lang = crate::i18n::t();
     let target = target_label(p.target);
     match p.op {
         Op::AddPercent => format!(
-            "{:+.1}% {} {}",
-            p.magnitude * 100.0,
+            "{} {} {}",
+            percent_magnitude(p.magnitude),
             lang.tree_blurb_to,
             target
         ),
-        Op::MulFactor => format!("×{:.2} {} {}", p.magnitude, lang.tree_blurb_to, target),
-        Op::FlatAdd => format!("{:+.1} {} {}", p.magnitude, lang.tree_blurb_flat_to, target),
-        Op::CostMul => format!("×{:.2} {} {}", p.magnitude, lang.tree_blurb_cost_on, target),
+        Op::MulFactor => format!(
+            "{} {} {}",
+            mul_magnitude(p.magnitude),
+            lang.tree_blurb_to,
+            target
+        ),
+        Op::FlatAdd => format!(
+            "{} {} {}",
+            flat_magnitude(p.magnitude),
+            lang.tree_blurb_flat_to,
+            target
+        ),
+        Op::CostMul => format!(
+            "{} {} {}",
+            mul_magnitude(p.magnitude),
+            lang.tree_blurb_cost_on,
+            target
+        ),
         Op::SpawnRateMul => format!(
-            "×{:.2} {} {}",
-            p.magnitude, lang.tree_blurb_spawn_rate_for, target
+            "{} {} {}",
+            mul_magnitude(p.magnitude),
+            lang.tree_blurb_spawn_rate_for,
+            target
         ),
         Op::EffectMul => format!(
-            "×{:.2} {} {}",
-            p.magnitude, lang.tree_blurb_effect_on, target
+            "{} {} {}",
+            mul_magnitude(p.magnitude),
+            lang.tree_blurb_effect_on,
+            target
         ),
     }
 }

--- a/src/game/tree/node.rs
+++ b/src/game/tree/node.rs
@@ -14,6 +14,9 @@
 //! `edge_exists(a, b)` from a position-seeded RNG, so the connectivity
 //! pattern is also stable forever.
 
+use std::cell::RefCell;
+use std::collections::HashMap;
+
 use super::coord::TreeCoord;
 use super::naming::make_title;
 use super::noise::{fbm_2d, value_noise_2d};
@@ -74,7 +77,7 @@ pub struct NodeSpec {
     pub box_h: u16,
     pub rarity: Rarity,
     pub primitives: Vec<Primitive>,
-    pub cost: f64,
+    pub cost: crate::bignum::Mag,
     pub title: String,
     /// Dominant target hint — used by the renderer for biome-color tinting.
     /// Picked as the target of the first primitive in the rolled stack.
@@ -92,11 +95,11 @@ const SALT_NODE: u64 = 0xA1;
 const SALT_EDGE: u64 = 0xED;
 const SALT_GAP: u64 = 0x6A;
 
-/// Pure-local "is this lot allowed to hold a node?" predicate. Doesn't
-/// recurse, doesn't check neighbors — just the gap roll and the
-/// always-populated origin neighborhood. Composing this with the
-/// has-at-least-one-populated-neighbor check (in `node_at`) is how the
-/// procgen suppresses truly-isolated lots.
+/// Pre-suppression predicate: does the local gap roll for this lot say
+/// "populated"? Origin neighborhood (|x|<=1 AND |y|<=1) is forced
+/// populated regardless of the roll. This is the *raw* "could this lot
+/// hold a node" check — orphan suppression on top of it lives in
+/// `reaches_origin`, which is what `node_at` actually gates on.
 fn passes_gap_roll(x: i32, y: i32) -> bool {
     let is_origin_neighborhood = x.abs() <= 1 && y.abs() <= 1;
     if is_origin_neighborhood {
@@ -132,7 +135,7 @@ fn anchor_spec() -> NodeSpec {
         box_h,
         rarity: Rarity::Small,
         primitives: Vec::new(),
-        cost: 0.0,
+        cost: crate::bignum::Mag::ZERO,
         title: "The Cuque".to_string(),
         dominant_target: Target::Fingerer(0),
         is_anchor: true,
@@ -146,19 +149,16 @@ pub fn node_at(x: i32, y: i32) -> Option<NodeSpec> {
     if x == 0 && y == 0 {
         return Some(anchor_spec());
     }
-    if !passes_gap_roll(x, y) {
-        return None;
-    }
-    // Suppress truly-isolated lots — populated lots that have ZERO
-    // populated king-neighbors. Such nodes would be unreachable forever
-    // (no anchor edge, no procgen edge possible) and are confusing
-    // visual noise. With the 80% population rate this only ever fires
-    // on lots with 8 consecutive gap rolls (P ≈ 2.6 × 10⁻⁶), but those
-    // do appear deep in the canvas — and they look like bugs.
-    let has_pop_neighbor = neighbors_of(TreeCoord::new(x, y))
-        .iter()
-        .any(|n| passes_gap_roll(n.x, n.y));
-    if !has_pop_neighbor {
+    // Orphan suppression: a lot is a real node only if there is a
+    // *strictly-decreasing-manhattan* chain of populated king-neighbors
+    // back to origin. The plain "passes_gap_roll AND has a populated
+    // neighbor" check used previously allowed isolated pairs at the
+    // tree's outskirts to become each other's parent — visible as nodes
+    // disconnected from the rest of the tree that the player can never
+    // reach. See `reaches_origin` for the predicate; `anchor_of` uses
+    // the same reachability check so anchor edges never point at a
+    // suppressed lot.
+    if !reaches_origin(TreeCoord::new(x, y)) {
         return None;
     }
 
@@ -351,7 +351,14 @@ fn roll_magnitude(
     // Base "strength multiplier" scales with rarity AND with manhattan
     // distance from origin: deeper lots roll harder magnitudes.
     let dist = x.unsigned_abs().saturating_add(y.unsigned_abs()) as f64;
-    let depth_scale = 1.0 + (dist / 12.0).min(20.0); // capped so keystones don't run away
+    // depth_scale cap was 20.0; tightened to 10.0 because every per-node
+    // boon stacks across hundreds of bought nodes in the late game, and
+    // a 20× depth multiplier on top of the per-roll range produced
+    // late-game players whose fps overflowed `f64` (cuques shown as `?`
+    // in the HUD, all next-buy costs `?`). The combination of a smaller
+    // cap here plus the 1000× shrink on the per-roll ranges keeps even
+    // a 1000+ node late-game stack bounded.
+    let depth_scale = 1.0 + (dist / 12.0).min(10.0);
     let rarity_scale = match rarity {
         Rarity::Small => 1.0,
         Rarity::Notable => 2.5,
@@ -371,52 +378,85 @@ fn roll_magnitude(
         }
     };
 
+    // Per-node magnitudes are all ~1000× smaller than the first cut of
+    // the tree (which gave keystone-class buffs like ×1.17 Green Coin
+    // spawn rate; two or three stacked turned spawns into a continuous
+    // rain and FPS into `Infinity` after a single long session). The
+    // shape — boons biased positive, banes biased negative, depth and
+    // rarity scale through `s` — is identical; only the absolute scale
+    // has shrunk. Keystones still feel distinct from Smalls because the
+    // 5× rarity_scale stays, and deep regions still hit harder than
+    // origin via depth_scale; both effects just compound much more
+    // gently when 500+ nodes are owned.
     match op {
         Op::AddPercent => {
-            // Small node: 1-5% additive; Keystone boon: up to 40%+.
-            let mag = rng.range_f64(0.01, 0.05) * s;
+            // Per-node boon at d=0 Small: +0.001% to +0.005% additive.
+            // At d=100 Keystone: ~+0.5% per node. Stack of 1000 deep
+            // keystones ≈ +5 total (additive), reasonable late-game.
+            let mag = rng.range_f64(0.00001, 0.00005) * s;
             if bane { -mag * 0.7 } else { mag }
         }
         Op::MulFactor => {
-            // Multiplicative boons: 1.05× small, 2-5× keystone.
-            let boost = rng.range_f64(0.02, 0.10) * s; // additive 'extra'
+            // Multiplicative — compounds across the player's bought set.
+            // Knocked down ANOTHER 100× past the 1000× rebalance because
+            // even ×1.005 per node stacked 10k nodes deep was reaching
+            // ×5e21 total. At ×1.00005 per node, 10k nodes is ×1.65,
+            // 100k is ×148 — game stays long.
+            let boost = rng.range_f64(0.0000002, 0.000001) * s;
             if bane {
-                // Bane mul: 0.5x ... 0.85x (rarer); deeper = more punishing
-                let nerf = rng.range_f64(0.05, 0.40).min(0.50);
-                (1.0 - nerf).max(0.01)
+                let nerf = rng.range_f64(0.0000005, 0.000004).min(0.00001);
+                (1.0 - nerf).max(0.9999)
             } else {
-                1.0 + boost
+                (1.0 + boost).min(1.00005)
             }
         }
         Op::FlatAdd => {
-            let mag = rng.range_f64(0.5, 4.0) * s;
+            // Flat FPS additions are linear (no compounding), so the
+            // 1000× shrink stays — these don't suffer from the runaway
+            // problem MulFactor/EffectMul do. Adding more nodes adds
+            // FPS additively, exactly the linear-grind path we want.
+            let mag = rng.range_f64(0.0005, 0.004) * s;
             if bane { -mag * 0.5 } else { mag }
         }
         Op::CostMul => {
-            // < 1 is boon (discount), > 1 is bane (inflation).
-            let scale = rng.range_f64(0.02, 0.10) * (1.0 + (dist / 30.0));
+            // Multiplicative on fingerer buy cost. Another 100× tighter
+            // so even a deep stack of discounts can't trivialize the
+            // cost ladder we're explicitly stretching.
+            let scale = rng.range_f64(0.0000002, 0.000001) * (1.0 + (dist / 30.0));
             if bane {
-                (1.0 + scale).min(2.0)
+                (1.0 + scale).min(1.00005)
             } else {
-                (1.0 - scale).max(0.50)
+                (1.0 - scale).max(0.99995)
             }
         }
         Op::SpawnRateMul => {
-            // > 1 is boon (more frequent), < 1 is bane (rarer).
-            let scale = rng.range_f64(0.02, 0.12) * (1.0 + (dist / 30.0));
+            // Multiplicative on powerup spawn frequency. The headline
+            // regression that started this thread was a single ×1.17
+            // GreenCoin SpawnRate. After the 1000× shrink the cap was
+            // ×1.005 — still produced ×148 from a 1000-node stack
+            // (constant-spawn territory). Another 100× knocks the cap
+            // to ×1.00005, so 1000 nodes → ×1.05 spawn rate, barely
+            // noticeable. Game wants to be longer; cooldowns stay long.
+            let scale = rng.range_f64(0.0000002, 0.0000012) * (1.0 + (dist / 30.0));
             if bane {
-                (1.0 - scale).max(0.30)
+                (1.0 - scale).max(0.99995)
             } else {
-                (1.0 + scale).min(3.0)
+                (1.0 + scale).min(1.00005)
             }
         }
         Op::EffectMul => {
-            // > 1 is boon, < 1 is bane.
-            let scale = rng.range_f64(0.02, 0.15) * (1.0 + (dist / 24.0));
+            // Multiplicative AND two-stage compounding — amplifies the
+            // catch-time mult that itself gets persisted on a fingerer.
+            // This is the path that produced the 311-trillion-x
+            // PurpleCoin in the wild save. Another 100× tightening to
+            // ×1.0001 cap means 10k deep nodes → ~×2.7 catch amplifier,
+            // not ×1e43. Keeps catch-time mults inside small-integer
+            // territory across any realistic session.
+            let scale = rng.range_f64(0.0000002, 0.0000015) * (1.0 + (dist / 24.0));
             if bane {
-                (1.0 - scale).max(0.10)
+                (1.0 - scale).max(0.9999)
             } else {
-                (1.0 + scale).min(5.0)
+                (1.0 + scale).min(1.0001)
             }
         }
     }
@@ -436,7 +476,14 @@ pub const NODE_COST_MULT: f64 = 5.0;
 /// Reference: fingerers grow at 1.15^count (classic Cookie Clicker
 /// 15%-per-buy). The tree grows much steeper because each "lot step"
 /// gives only ONE upgrade, vs many buys per fingerer.
-pub const NODE_COST_GROWTH: f64 = 1.75;
+///
+/// Bumped 1.75 → 2.5 along with the 1000× shrink in `roll_magnitude`.
+/// Per-node power is now tiny, so the player wants to buy *many*
+/// nodes; a steeper cost ramp keeps the player from sweeping the
+/// entire frontier in a single session and lets the alphabetic-suffix
+/// number range (10^36+ and beyond) become a real late-game milestone
+/// instead of a transient overflow.
+pub const NODE_COST_GROWTH: f64 = 2.5;
 
 /// Base cost at distance 0 (before rarity and jitter). The origin lot
 /// is auto-owned so this never quotes a real purchase, but it anchors
@@ -444,26 +491,32 @@ pub const NODE_COST_GROWTH: f64 = 1.75;
 ///                    * rarity_factor * jitter.
 pub const NODE_BASE_COST: f64 = 50.0;
 
-pub fn roll_cost(x: i32, y: i32, rarity: Rarity) -> f64 {
+pub fn roll_cost(x: i32, y: i32, rarity: Rarity) -> crate::bignum::Mag {
+    use crate::bignum::Mag;
     let dist = x.unsigned_abs().saturating_add(y.unsigned_abs()) as f64;
-    let depth_factor = NODE_COST_GROWTH.powf(dist);
-    let rarity_factor = match rarity {
+    let rarity_factor: f64 = match rarity {
         Rarity::Small => 1.0,
         Rarity::Notable => 5.0,
         Rarity::Keystone => 40.0,
     };
-    // Tiny per-lot jitter so adjacent same-rarity nodes don't all cost
-    // exactly the same.
     let mut rng = SplitMix64::from_coords(TREE_SEED, x, y, 0xC0);
     let jitter = rng.range_f64(0.85, 1.25);
-    // `NODE_COST_GROWTH.powf(dist)` overflows to `f64::INFINITY` around
-    // dist ≈ 1232 (at growth=1.75). Clamp to a safe ceiling so the
-    // info-pane "Cost: ?" path is replaced by a real finite quote — the
-    // player won't ever afford it anyway, but the rendering and the
-    // `affordable_cuques() >= cost` check both behave better with a
-    // concrete number.
-    let raw = NODE_COST_MULT * NODE_BASE_COST * depth_factor * rarity_factor * jitter;
-    raw.min(1e300).floor().max(10.0)
+    // Compute directly in log10 space so very-deep nodes (`dist` in
+    // the thousands) produce a faithful Mag instead of the old
+    // `.min(1e300)`-clamped placeholder. Each multiplicative factor is
+    // log10'd and summed; the result is `10^(sum)`.
+    let log10 = NODE_COST_MULT.log10()
+        + NODE_BASE_COST.log10()
+        + dist * NODE_COST_GROWTH.log10()
+        + rarity_factor.log10()
+        + jitter.log10();
+    // `.max` a small floor so even the cheapest origin-neighborhood node
+    // isn't free: 10 cuques minimum.
+    if log10 < 1.0 {
+        Mag::from_f64(10.0)
+    } else {
+        Mag { log10 }
+    }
 }
 
 /// True when the lots at `a` and `b` are 8-king neighbors (chebyshev
@@ -480,23 +533,25 @@ pub fn is_king_neighbor(a: TreeCoord, b: TreeCoord) -> bool {
 ///
 /// Selection rules, in order:
 ///   1. Prefer an ORTHOGONAL king-neighbor at strictly smaller manhattan
-///      distance from origin. This is what controls the cobweb at
-///      origin: only origin's 4 orthogonal neighbors will anchor to
-///      origin directly, while diagonal neighbors anchor via one of the
-///      orthogonal cousins. Cuts origin's incoming anchor-edge count
-///      from 8 to 4, halving the visual density.
-///   2. Fall back to a DIAGONAL strictly-smaller-manhattan neighbor if
-///      no orthogonal candidate exists (happens when all 4 orth
-///      neighbors are gaps — rare but possible at gap_p=0.35).
-///   3. Last resort: any populated king-neighbor (same/greater
-///      manhattan). Belt-and-suspenders; almost never triggers.
+///      distance from origin that itself reaches origin. This is what
+///      controls the cobweb at origin: only origin's 4 orthogonal
+///      neighbors will anchor to origin directly, while diagonal
+///      neighbors anchor via one of the orthogonal cousins. Cuts
+///      origin's incoming anchor-edge count from 8 to 4.
+///   2. Fall back to a DIAGONAL strictly-smaller-manhattan neighbor
+///      that reaches origin.
 ///
-/// Returns `None` for origin (no parent) and for unpopulated lots.
+/// Returns `None` for origin (no parent) and for lots that fail
+/// `reaches_origin`. There is deliberately no "any populated neighbor"
+/// fallback — that used to exist and was the source of orphan islands:
+/// two adjacent populated lots whose only smaller-manhattan neighbors
+/// were all gaps would each point at the other, forming a closed loop
+/// disconnected from the rest of the tree.
 pub fn anchor_of(lot: TreeCoord) -> Option<TreeCoord> {
     if lot == TreeCoord::ORIGIN {
         return None;
     }
-    if !passes_gap_roll(lot.x, lot.y) {
+    if !reaches_origin(lot) {
         return None;
     }
     let dist = lot.manhattan();
@@ -510,7 +565,7 @@ pub fn anchor_of(lot: TreeCoord) -> Option<TreeCoord> {
         let dy = n.y.wrapping_sub(lot.y).unsigned_abs();
         (dx == 0 || dy == 0) && (dx + dy == 1)
     };
-    // Pass 1: orthogonal + strictly-smaller-manhattan + populated.
+    // Pass 1: orthogonal + strictly-smaller-manhattan + reaches-origin.
     for n in &candidates {
         if n.manhattan() >= dist {
             continue;
@@ -518,28 +573,66 @@ pub fn anchor_of(lot: TreeCoord) -> Option<TreeCoord> {
         if !is_orthogonal(n) {
             continue;
         }
-        if passes_gap_roll(n.x, n.y) {
+        if reaches_origin(*n) {
             return Some(*n);
         }
     }
-    // Pass 2: diagonal + strictly-smaller-manhattan + populated. Lets
-    // a lot whose 4 orthogonal neighbors are all gaps still find a
-    // parent toward origin.
+    // Pass 2: diagonal + strictly-smaller-manhattan + reaches-origin.
+    // Lets a lot whose 4 orthogonal neighbors all fail (gap or orphaned)
+    // still find a parent toward origin.
     for n in &candidates {
         if n.manhattan() >= dist {
             continue;
         }
-        if passes_gap_roll(n.x, n.y) {
-            return Some(*n);
-        }
-    }
-    // Pass 3: any populated neighbor. Last resort.
-    for n in &candidates {
-        if passes_gap_roll(n.x, n.y) {
+        if reaches_origin(*n) {
             return Some(*n);
         }
     }
     None
+}
+
+// Memoized "is this lot connected to origin via a strictly-decreasing-
+// manhattan chain of populated king-neighbors". Pure function of
+// (lot.x, lot.y) — the procgen seed and gap-roll function are both
+// deterministic — so caching results forever is sound. The map only
+// grows as the player explores; in practice it stays in the low
+// thousands of entries (one per lot the renderer ever asks about).
+thread_local! {
+    static REACHES_ORIGIN_MEMO: RefCell<HashMap<TreeCoord, bool>> = RefCell::new(HashMap::new());
+}
+
+/// True iff `lot` admits a path of populated king-neighbors back to
+/// origin where every step strictly *decreases* manhattan distance.
+/// Origin itself returns true; unpopulated lots (gap roll) return false.
+///
+/// The strict-decrease constraint is what makes the procgen orphan-free:
+/// it's impossible to form a cycle among lots if every edge in the
+/// chain reduces a non-negative integer (manhattan distance), so any
+/// successful chain terminates at origin in at most `lot.manhattan()`
+/// steps. Recursion depth is therefore bounded by manhattan distance,
+/// and the thread-local memo collapses overlapping sub-chains across
+/// the many lots the renderer asks about per frame.
+pub fn reaches_origin(lot: TreeCoord) -> bool {
+    if lot == TreeCoord::ORIGIN {
+        return true;
+    }
+    if let Some(v) = REACHES_ORIGIN_MEMO.with(|m| m.borrow().get(&lot).copied()) {
+        return v;
+    }
+    if !passes_gap_roll(lot.x, lot.y) {
+        REACHES_ORIGIN_MEMO.with(|m| m.borrow_mut().insert(lot, false));
+        return false;
+    }
+    let dist = lot.manhattan();
+    let mut result = false;
+    for n in neighbors_of(lot) {
+        if n.manhattan() < dist && reaches_origin(n) {
+            result = true;
+            break;
+        }
+    }
+    REACHES_ORIGIN_MEMO.with(|m| m.borrow_mut().insert(lot, result));
+    result
 }
 
 /// Sample a low-frequency density noise field at the midpoint between
@@ -933,18 +1026,18 @@ mod tests {
         // Walk a large region; for every keystone, assert composition.
         for x in -30..=30 {
             for y in -30..=30 {
-                if let Some(n) = node_at(x, y) {
-                    if n.rarity == Rarity::Keystone {
-                        assert!(
-                            n.primitives.iter().any(|p| p.is_bane()),
-                            "keystone at ({x},{y}) has no bane primitive: {:?}",
-                            n.primitives
-                        );
-                        assert!(
-                            n.primitives.iter().any(|p| !p.is_bane()),
-                            "keystone at ({x},{y}) has no boon primitive"
-                        );
-                    }
+                if let Some(n) = node_at(x, y)
+                    && n.rarity == Rarity::Keystone
+                {
+                    assert!(
+                        n.primitives.iter().any(|p| p.is_bane()),
+                        "keystone at ({x},{y}) has no bane primitive: {:?}",
+                        n.primitives
+                    );
+                    assert!(
+                        n.primitives.iter().any(|p| !p.is_bane()),
+                        "keystone at ({x},{y}) has no boon primitive"
+                    );
                 }
             }
         }
@@ -954,7 +1047,13 @@ mod tests {
     fn cost_grows_with_distance() {
         let near = roll_cost(0, 0, Rarity::Small);
         let far = roll_cost(20, 20, Rarity::Small);
-        assert!(far > near * 100.0, "far ({far}) should be >> near ({near})");
+        // log10(far) - log10(near) >= 2 means far >= 100x near.
+        assert!(
+            far.log10 - near.log10 > 2.0,
+            "far ({}) should be >> near ({})",
+            crate::format::big_mag(far),
+            crate::format::big_mag(near)
+        );
     }
 
     /// Diagnostic table — not a real assertion, prints the live ramp at
@@ -974,21 +1073,21 @@ mod tests {
             "dist", "Small", "Notable", "Keystone"
         );
         for &d in &[1, 2, 3, 5, 7, 10, 12, 15, 18, 20, 25, 30, 35, 40, 50i32] {
-            // Use (d, 0) so manhattan == d. Average over a small sample to
-            // smooth out jitter, since jitter is seeded from (x, y).
+            // Use (d, 0) so manhattan == d.
             let small = roll_cost(d, 0, Rarity::Small);
             let notable = roll_cost(d, 0, Rarity::Notable);
             let keystone = roll_cost(d, 0, Rarity::Keystone);
             eprintln!(
                 "{:>4}  {:>14}  {:>14}  {:>14}",
                 d,
-                format_cost(small),
-                format_cost(notable),
-                format_cost(keystone)
+                crate::format::big_mag(small),
+                crate::format::big_mag(notable),
+                crate::format::big_mag(keystone)
             );
         }
     }
 
+    #[allow(dead_code)]
     fn format_cost(c: f64) -> String {
         if c >= 1e15 {
             format!("{:.2} quad", c / 1e15)
@@ -1024,6 +1123,96 @@ mod tests {
                                 (i as usize) < FINGERERS.len(),
                                 "fingerer target idx {i} out of range"
                             );
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn no_orphan_components_within_visible_radius() {
+        use std::collections::{HashSet, VecDeque};
+        // 40 covers a generous "explore for an hour" radius. Before the
+        // `reaches_origin` orphan check this would surface ~50 orphans;
+        // the player saw them as isolated 2-node islands in the panned
+        // canvas with no path back to The Cuque.
+        let radius: i32 = 40;
+        let mut populated: HashSet<TreeCoord> = HashSet::new();
+        for x in -radius..=radius {
+            for y in -radius..=radius {
+                if node_at(x, y).is_some() {
+                    populated.insert(TreeCoord::new(x, y));
+                }
+            }
+        }
+        let mut reached: HashSet<TreeCoord> = HashSet::new();
+        let mut q: VecDeque<TreeCoord> = VecDeque::new();
+        q.push_back(TreeCoord::ORIGIN);
+        reached.insert(TreeCoord::ORIGIN);
+        while let Some(c) = q.pop_front() {
+            for n in neighbors_of(c) {
+                if !populated.contains(&n) {
+                    continue;
+                }
+                if reached.contains(&n) {
+                    continue;
+                }
+                if edge_exists(c, n) {
+                    reached.insert(n);
+                    q.push_back(n);
+                }
+            }
+        }
+        let orphans: Vec<_> = populated.difference(&reached).copied().collect();
+        if !orphans.is_empty() {
+            for o in orphans.iter().take(20) {
+                eprintln!("orphan at ({}, {}) manhattan={}", o.x, o.y, o.manhattan());
+            }
+        }
+        assert!(
+            orphans.is_empty(),
+            "{} orphan(s) detected in radius {}",
+            orphans.len(),
+            radius
+        );
+    }
+
+    #[test]
+    fn multiplicative_primitives_stay_under_per_node_caps() {
+        // Per-node caps are the load-bearing balance knob for keeping the
+        // game long: every multiplicative op compounds across the bought
+        // set, so a generous cap turns into runaway numbers. Caps were
+        // tightened ANOTHER 100× past the initial rebalance after the
+        // "make the game longer" pass:
+        //   MulFactor / CostMul / SpawnRateMul: ×1.00005
+        //   EffectMul:                          ×1.0001
+        // EffectMul gets a slightly looser ceiling because it's
+        // applied at catch time (once per powerup), not on every fps
+        // tick like the others.
+        const MUL_CAP: f64 = 1.00005;
+        const EFFECT_CAP: f64 = 1.0001;
+        for x in -60..=60 {
+            for y in -60..=60 {
+                if let Some(n) = node_at(x, y) {
+                    for p in &n.primitives {
+                        match p.op {
+                            Op::MulFactor | Op::CostMul | Op::SpawnRateMul => {
+                                assert!(
+                                    p.magnitude <= MUL_CAP + 1e-12,
+                                    "{:?} at ({x},{y}) is {} (cap {MUL_CAP})",
+                                    p.op,
+                                    p.magnitude
+                                );
+                            }
+                            Op::EffectMul => {
+                                assert!(
+                                    p.magnitude <= EFFECT_CAP + 1e-12,
+                                    "EffectMul at ({x},{y}) is {} (cap {EFFECT_CAP})",
+                                    p.magnitude
+                                );
+                            }
+                            _ => {}
                         }
                     }
                 }

--- a/src/game/tree/rng.rs
+++ b/src/game/tree/rng.rs
@@ -106,7 +106,7 @@ mod tests {
         let mut r = SplitMix64::new(1234);
         for _ in 0..1000 {
             let v = r.range_f64(-2.0, 5.0);
-            assert!(v >= -2.0 && v < 5.0, "{}", v);
+            assert!((-2.0..5.0).contains(&v), "{}", v);
         }
     }
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -905,7 +905,7 @@ mod tests {
         // prestige_available() square-roots `lifetime_cuques / 1e9` and
         // floors. 4e9 → 2 prestige tokens.
         GameState {
-            lifetime_cuques: 4_000_000_000.0,
+            lifetime_cuques: crate::bignum::Mag::from_f64(4_000_000_000.0),
             ..GameState::default()
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@
 //! `InstanceLock` are re-exported with the same struct/method shape on
 //! both sides, so caller code outside `platform::` is portable.
 
+pub mod bignum;
 pub mod build_info;
 pub mod format;
 pub mod game;

--- a/src/save/mod.rs
+++ b/src/save/mod.rs
@@ -20,7 +20,7 @@ use crate::game::state::GameState;
 
 /// The version number every fresh save is written as. Bump in lockstep
 /// with adding a new `versions/vN.rs` and routing it in [`load_from_str`].
-pub const CURRENT_VERSION: u32 = 4;
+pub const CURRENT_VERSION: u32 = 5;
 
 /// Best-effort load from a JSON string. Falls back to a default state if
 /// the input is malformed at any layer of the chain. The result is always
@@ -31,29 +31,34 @@ pub const CURRENT_VERSION: u32 = 4;
 /// pessimistic on purpose (a future version is more likely to have new
 /// fields than the current code can interpret).
 pub fn load_from_str(json: &str) -> GameState {
+    use versions::{v1, v2, v3, v4, v5};
     match migrate::peek_version(json) {
-        1 => match serde_json::from_str::<versions::v1::GameStateV1>(json) {
-            Ok(v1) => versions::v4::GameStateV4::from(versions::v3::GameStateV3::from(
-                versions::v2::GameStateV2::from(v1),
-            ))
+        1 => match serde_json::from_str::<v1::GameStateV1>(json) {
+            Ok(v) => v5::GameStateV5::from(v4::GameStateV4::from(v3::GameStateV3::from(
+                v2::GameStateV2::from(v),
+            )))
             .into_current()
             .migrate_runtime(),
             Err(_) => GameState::default().migrate_runtime(),
         },
-        2 => match serde_json::from_str::<versions::v2::GameStateV2>(json) {
-            Ok(v2) => versions::v4::GameStateV4::from(versions::v3::GameStateV3::from(v2))
+        2 => match serde_json::from_str::<v2::GameStateV2>(json) {
+            Ok(v) => v5::GameStateV5::from(v4::GameStateV4::from(v3::GameStateV3::from(v)))
                 .into_current()
                 .migrate_runtime(),
             Err(_) => GameState::default().migrate_runtime(),
         },
-        3 => match serde_json::from_str::<versions::v3::GameStateV3>(json) {
-            Ok(v3) => versions::v4::GameStateV4::from(v3)
+        3 => match serde_json::from_str::<v3::GameStateV3>(json) {
+            Ok(v) => v5::GameStateV5::from(v4::GameStateV4::from(v))
                 .into_current()
                 .migrate_runtime(),
             Err(_) => GameState::default().migrate_runtime(),
         },
-        4 => match serde_json::from_str::<versions::v4::GameStateV4>(json) {
-            Ok(v4) => v4.into_current().migrate_runtime(),
+        4 => match serde_json::from_str::<v4::GameStateV4>(json) {
+            Ok(v) => v5::GameStateV5::from(v).into_current().migrate_runtime(),
+            Err(_) => GameState::default().migrate_runtime(),
+        },
+        5 => match serde_json::from_str::<v5::GameStateV5>(json) {
+            Ok(v) => v.into_current().migrate_runtime(),
             Err(_) => GameState::default().migrate_runtime(),
         },
         _ => GameState::default().migrate_runtime(),
@@ -73,15 +78,20 @@ pub fn load_from_str(json: &str) -> GameState {
 /// once can poison `cuques` / `lifetime_cuques` and we'd rather lose
 /// the corruption than lose subsequent saves.
 pub fn save_to_string(state: &GameState) -> serde_json::Result<String> {
+    // With Mag-typed counters, "non-finite" is no longer reachable —
+    // `Mag` stores log10 and saturates on impossible inputs. The clone+
+    // sanitize dance is preserved as belt-and-suspenders against any
+    // future buggy assignment that puts a NaN into the log10 field; if
+    // we ever see one, fall the affected counter back to zero.
     let mut sanitized = state.clone();
-    if !sanitized.cuques.is_finite() {
-        sanitized.cuques = 0.0;
+    if sanitized.cuques.log10.is_nan() {
+        sanitized.cuques = crate::bignum::Mag::ZERO;
     }
-    if !sanitized.lifetime_cuques.is_finite() {
-        sanitized.lifetime_cuques = 0.0;
+    if sanitized.lifetime_cuques.log10.is_nan() {
+        sanitized.lifetime_cuques = crate::bignum::Mag::ZERO;
     }
-    if !sanitized.best_fps.is_finite() {
-        sanitized.best_fps = 0.0;
+    if sanitized.best_fps.log10.is_nan() {
+        sanitized.best_fps = crate::bignum::Mag::ZERO;
     }
     serde_json::to_string_pretty(&sanitized)
 }
@@ -110,7 +120,7 @@ mod tests {
         }"#;
         let s = load_from_str(legacy);
         assert_eq!(s.version, CURRENT_VERSION);
-        assert_eq!(s.cuques, 1234.5);
+        assert_eq!(s.cuques, crate::bignum::Mag::from_f64(1234.5));
         assert_eq!(s.total_clicks, 99);
         assert_eq!(s.fingerer_count("index_finger"), 7);
         assert!(s.has_achievement("first_finger"));
@@ -128,21 +138,73 @@ mod tests {
     #[test]
     fn malformed_json_falls_back_to_default() {
         let s = load_from_str("{ not valid json");
-        assert_eq!(s.cuques, 0.0);
+        assert_eq!(s.cuques, crate::bignum::Mag::ZERO);
         assert_eq!(s.version, CURRENT_VERSION);
     }
 
     #[test]
     fn round_trip_through_save_to_string_preserves_state() {
         let original = GameState {
-            cuques: 4242.0,
+            cuques: crate::bignum::Mag::from_f64(4242.0),
             total_clicks: 17,
             ..GameState::default()
         };
         let json = save_to_string(&original).expect("serialize");
         let loaded = load_from_str(&json);
-        assert_eq!(loaded.cuques, 4242.0);
+        assert_eq!(loaded.cuques, crate::bignum::Mag::from_f64(4242.0));
         assert_eq!(loaded.total_clicks, 17);
         assert_eq!(loaded.version, CURRENT_VERSION);
+    }
+
+    #[test]
+    fn round_trip_preserves_huge_mag_values_past_f64_range() {
+        // Regression for the V5-blocker: before the bump, `Mag` serialized
+        // as `{"log10": x}` once it cleared `f64`-finite range, but the
+        // V4 frozen schema's `cuques: f64` rejected the struct shape and
+        // `load_from_str` silently fell back to `default()` — wiping the
+        // entire save. With V5 declaring Mag-typed counters, the struct
+        // form is now part of the schema and the round-trip survives.
+        let original = GameState {
+            cuques: crate::bignum::Mag { log10: 600.0 },
+            lifetime_cuques: crate::bignum::Mag { log10: 1200.0 },
+            best_fps: crate::bignum::Mag { log10: 750.0 },
+            ..GameState::default()
+        };
+        let json = save_to_string(&original).expect("serialize");
+        let loaded = load_from_str(&json);
+        assert!((loaded.cuques.log10 - 600.0).abs() < 1e-9);
+        assert!((loaded.lifetime_cuques.log10 - 1200.0).abs() < 1e-9);
+        assert!((loaded.best_fps.log10 - 750.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn v4_json_with_plain_number_fields_still_loads_under_v5() {
+        // A V4-shaped save (`"cuques": 1234.5`) must still parse cleanly
+        // through the V5 reader. The `Mag` untagged-serde shim accepts
+        // bare JSON numbers exactly because of this requirement.
+        let v4_json = r#"{
+            "version": 4,
+            "cuques": 1234.5,
+            "total_clicks": 88,
+            "lifetime_cuques": 6789.0,
+            "best_fps": 12.0,
+            "golden_caught": 0,
+            "lucky_caught": 0,
+            "frenzy_caught": 0,
+            "buff_caught": 0,
+            "green_coin_caught": 0,
+            "fingerers_state": {},
+            "achievements_earned": [],
+            "prestige": 2,
+            "total_play_ticks": 4242,
+            "buffs": [],
+            "tree": { "bought": [], "cursor": {"x": 0, "y": 0}, "last_bought": null }
+        }"#;
+        let loaded = load_from_str(v4_json);
+        assert_eq!(loaded.version, CURRENT_VERSION);
+        assert!((loaded.cuques.to_f64() - 1234.5).abs() < 1e-9);
+        assert!((loaded.lifetime_cuques.to_f64() - 6789.0).abs() < 1e-9);
+        assert_eq!(loaded.total_clicks, 88);
+        assert_eq!(loaded.prestige, 2);
     }
 }

--- a/src/save/versions/mod.rs
+++ b/src/save/versions/mod.rs
@@ -9,3 +9,4 @@ pub mod v1;
 pub mod v2;
 pub mod v3;
 pub mod v4;
+pub mod v5;

--- a/src/save/versions/v1.rs
+++ b/src/save/versions/v1.rs
@@ -103,10 +103,10 @@ mod tests {
         let s = v1.into_current();
 
         assert_eq!(s.version, crate::save::CURRENT_VERSION);
-        assert_eq!(s.cuques, 12345.6);
+        assert_eq!(s.cuques, crate::bignum::Mag::from_f64(12345.6));
         assert_eq!(s.total_clicks, 42);
-        assert_eq!(s.lifetime_cuques, 99999.0);
-        assert_eq!(s.best_fps, 17.5);
+        assert_eq!(s.lifetime_cuques, crate::bignum::Mag::from_f64(99999.0));
+        assert_eq!(s.best_fps, crate::bignum::Mag::from_f64(17.5));
         assert_eq!(s.golden_caught, 3);
         assert_eq!(s.fingerer_count("index_finger"), 9);
         assert_eq!(s.fingerer_count("latex_glove"), 4);
@@ -179,6 +179,6 @@ mod tests {
             crate::game::modifier::ModifierDuration::Ticks(600)
         ));
         // Remaining time and mult survive.
-        assert!((st.aggregate.mul_factor - 7.0).abs() < 1e-9);
+        assert!((st.aggregate.mul_factor.to_f64() - 7.0).abs() < 1e-9);
     }
 }

--- a/src/save/versions/v2.rs
+++ b/src/save/versions/v2.rs
@@ -47,7 +47,9 @@ impl From<ModifierEffectV2> for ModifierEffect {
         match e {
             ModifierEffectV2::FlatFps(v) => ModifierEffect::FlatFps(v),
             ModifierEffectV2::AddPercent(v) => ModifierEffect::AddPercent(v),
-            ModifierEffectV2::MulFactor(v) => ModifierEffect::MulFactor(v),
+            ModifierEffectV2::MulFactor(v) => {
+                ModifierEffect::MulFactor(crate::bignum::Mag::from_f64(v))
+            }
         }
     }
 }
@@ -489,7 +491,7 @@ mod tests {
         assert_eq!(st.count, 5);
         assert_eq!(st.modifiers.len(), 2);
         assert!((st.aggregate.add_percent - 0.10).abs() < 1e-9);
-        assert!((st.aggregate.mul_factor - 2.0).abs() < 1e-9);
+        assert!((st.aggregate.mul_factor.to_f64() - 2.0).abs() < 1e-9);
     }
 
     #[test]

--- a/src/save/versions/v3.rs
+++ b/src/save/versions/v3.rs
@@ -70,7 +70,10 @@ impl GameStateV3 {
     /// is the one mutation a frozen file is allowed: keeping the chain
     /// reachable as later versions land.)
     pub fn into_current(self) -> GameState {
-        super::v4::GameStateV4::from(self).into_current()
+        // Walk through V4 → V5 → GameState. V5 introduced Mag-typed
+        // counters; the previous "v4.into_current" shortcut moved its
+        // body into v5.
+        super::v5::GameStateV5::from(super::v4::GameStateV4::from(self)).into_current()
     }
 }
 

--- a/src/save/versions/v4.rs
+++ b/src/save/versions/v4.rs
@@ -20,7 +20,6 @@ use std::collections::{HashMap, HashSet};
 
 use super::v2::{BuffV2, FingererStateV2};
 use super::v3::GameStateV3;
-use crate::game::state::GameState;
 use crate::game::tree::UpgradeTreeState;
 
 fn default_v4_version() -> u32 {
@@ -65,38 +64,12 @@ pub struct GameStateV4 {
     pub tree: UpgradeTreeState,
 }
 
-impl GameStateV4 {
-    /// Convert a V4 snapshot into the live `GameState`. Persisted fields
-    /// copy verbatim; ephemeral state (`#[serde(skip)]` fields) stays at
-    /// `Default` and is seeded by `migrate_runtime`.
-    pub fn into_current(self) -> GameState {
-        let fingerers_state = self
-            .fingerers_state
-            .into_iter()
-            .map(|(id, st)| (id, st.into()))
-            .collect();
-        let buffs = self.buffs.into_iter().map(Into::into).collect();
-        GameState {
-            version: crate::save::CURRENT_VERSION,
-            cuques: self.cuques,
-            total_clicks: self.total_clicks,
-            lifetime_cuques: self.lifetime_cuques,
-            best_fps: self.best_fps,
-            golden_caught: self.golden_caught,
-            lucky_caught: self.lucky_caught,
-            frenzy_caught: self.frenzy_caught,
-            buff_caught: self.buff_caught,
-            green_coin_caught: self.green_coin_caught,
-            fingerers_state,
-            achievements_earned: self.achievements_earned,
-            prestige: self.prestige,
-            total_play_ticks: self.total_play_ticks,
-            buffs,
-            tree: self.tree,
-            ..GameState::default()
-        }
-    }
-}
+// V4's old `into_current` lived here when V4 was the current schema. The
+// V5 bump moved the live-state conversion to `v5::GameStateV5::into_current`
+// (the live `GameState` shape now requires `Mag` counters, which the V4
+// frozen schema doesn't carry). V4 saves on disk continue to load — the
+// chain now walks `v4 → v5 → GameState` — but the V4 module itself only
+// owns the persisted shape and the `From<GameStateV3>` step.
 
 /// V3 → V4 conversion. Drops `upgrades_earned` (old hardcoded UPGRADES
 /// catalog is retired); inits a fresh empty `UpgradeTreeState`. Every
@@ -242,11 +215,9 @@ mod tests {
     }
 
     #[test]
-    fn v4_into_current_rebuilds_tree_aggregate() {
-        // A V4 save with one bought node at origin should arrive in live
-        // state with the TreeAggregate already populated. The migrate_runtime
-        // step is what does this rebuild; here we just confirm the bought
-        // set survives the chain.
+    fn v4_through_v5_preserves_tree_state() {
+        // V4-on-disk → live state goes through V5 now. Round the V4
+        // fixture through the chain and confirm the bought set survives.
         let mut v4 = GameStateV4 {
             version: 4,
             cuques: 0.0,
@@ -267,7 +238,7 @@ mod tests {
         };
         v4.tree.bought.insert(TreeCoord::ORIGIN);
 
-        let live = v4.into_current();
+        let live = crate::save::versions::v5::GameStateV5::from(v4).into_current();
         assert!(live.tree.bought.contains(&TreeCoord::ORIGIN));
     }
 }

--- a/src/save/versions/v5.rs
+++ b/src/save/versions/v5.rs
@@ -1,0 +1,238 @@
+//! Save schema V5 — moves cuque-side counters and multiplier aggregates to
+//! [`crate::bignum::Mag`] (log-magnitude) so end-game stacks no longer
+//! overflow `f64` to `Infinity`.
+//!
+//! The persisted *wire* shape is intentionally backward-compatible: `Mag`
+//! ships an untagged serde shim that accepts both legacy raw JSON numbers
+//! (everything written before this bump used `"cuques": 1234.5`) and the
+//! explicit `{"log10": x}` form (new huge values past `f64::MAX`). So a
+//! V5 reader still parses every V4-written file; a V5 writer only emits
+//! the struct form when a value's log10 exceeds the `f64` range, keeping
+//! "small" saves indistinguishable from V4 on disk.
+//!
+//! V4 → V5 is mechanical: every `f64` counter / aggregate / cost becomes
+//! `Mag::from_f64(old)`, which collapses any `Inf` / `NaN` left behind by
+//! the runaway-overflow bug class V5 exists to kill into `Mag::ZERO`
+//! rather than reproducing it.
+//!
+//! Once V5 is on `main` this file is FROZEN. Subsequent schema changes
+//! go in `v6.rs` with a `From<GameStateV5>` conversion.
+//!
+//! Note: V5's persisted shape *is* the live `GameState` shape — moving
+//! to a Mag-typed counter set is a live-state change as much as a save
+//! change, so V5 has no new fields relative to V4. The whole point of
+//! V5 is the field *type* swap from `f64` → `Mag`.
+
+use serde::{Deserialize, Serialize};
+use std::collections::{HashMap, HashSet};
+
+use super::v2::{BuffV2, FingererStateV2};
+use super::v4::GameStateV4;
+use crate::bignum::Mag;
+use crate::game::state::GameState;
+use crate::game::tree::UpgradeTreeState;
+
+fn default_v5_version() -> u32 {
+    5
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+pub struct GameStateV5 {
+    #[serde(default = "default_v5_version")]
+    pub version: u32,
+    #[serde(default)]
+    pub cuques: Mag,
+    #[serde(default)]
+    pub total_clicks: u64,
+    #[serde(default)]
+    pub lifetime_cuques: Mag,
+    #[serde(default)]
+    pub best_fps: Mag,
+    #[serde(default)]
+    pub golden_caught: u64,
+    #[serde(default)]
+    pub lucky_caught: u64,
+    #[serde(default)]
+    pub frenzy_caught: u64,
+    #[serde(default)]
+    pub buff_caught: u64,
+    #[serde(default)]
+    pub green_coin_caught: u64,
+    #[serde(default)]
+    pub fingerers_state: HashMap<String, FingererStateV2>,
+    #[serde(default)]
+    pub achievements_earned: HashSet<String>,
+    #[serde(default)]
+    pub prestige: u64,
+    #[serde(default)]
+    pub total_play_ticks: u64,
+    #[serde(default)]
+    pub buffs: Vec<BuffV2>,
+    #[serde(default)]
+    pub tree: UpgradeTreeState,
+}
+
+impl GameStateV5 {
+    /// Convert a V5 snapshot into the live `GameState`. The persisted
+    /// fields copy verbatim; ephemeral state (`#[serde(skip)]` fields)
+    /// stays at `Default` and is seeded by `migrate_runtime`.
+    pub fn into_current(self) -> GameState {
+        let fingerers_state = self
+            .fingerers_state
+            .into_iter()
+            .map(|(id, st)| (id, st.into()))
+            .collect();
+        let buffs = self.buffs.into_iter().map(Into::into).collect();
+        GameState {
+            version: crate::save::CURRENT_VERSION,
+            cuques: self.cuques,
+            total_clicks: self.total_clicks,
+            lifetime_cuques: self.lifetime_cuques,
+            best_fps: self.best_fps,
+            golden_caught: self.golden_caught,
+            lucky_caught: self.lucky_caught,
+            frenzy_caught: self.frenzy_caught,
+            buff_caught: self.buff_caught,
+            green_coin_caught: self.green_coin_caught,
+            fingerers_state,
+            achievements_earned: self.achievements_earned,
+            prestige: self.prestige,
+            total_play_ticks: self.total_play_ticks,
+            buffs,
+            tree: self.tree,
+            ..GameState::default()
+        }
+    }
+}
+
+/// V4 → V5 conversion. Each f64 counter gets `Mag::from_f64`'d at the
+/// boundary; finite values copy faithfully, and `Inf` / `NaN` left over
+/// from corrupted V4 saves (the original bug we triaged had
+/// `cuques = 0.0` because the V4 saver had refused-to-serialize an
+/// `Infinity` and silently fell through to a zero) collapse to
+/// `Mag::ZERO`. Everything else passes through verbatim.
+impl From<GameStateV4> for GameStateV5 {
+    fn from(v4: GameStateV4) -> Self {
+        GameStateV5 {
+            version: 5,
+            cuques: Mag::from_f64(v4.cuques),
+            total_clicks: v4.total_clicks,
+            lifetime_cuques: Mag::from_f64(v4.lifetime_cuques),
+            best_fps: Mag::from_f64(v4.best_fps),
+            golden_caught: v4.golden_caught,
+            lucky_caught: v4.lucky_caught,
+            frenzy_caught: v4.frenzy_caught,
+            buff_caught: v4.buff_caught,
+            green_coin_caught: v4.green_coin_caught,
+            fingerers_state: v4.fingerers_state,
+            achievements_earned: v4.achievements_earned,
+            prestige: v4.prestige,
+            total_play_ticks: v4.total_play_ticks,
+            buffs: v4.buffs,
+            tree: v4.tree,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::game::tree::coord::TreeCoord;
+
+    fn empty_v4() -> GameStateV4 {
+        GameStateV4 {
+            version: 4,
+            cuques: 0.0,
+            total_clicks: 0,
+            lifetime_cuques: 0.0,
+            best_fps: 0.0,
+            golden_caught: 0,
+            lucky_caught: 0,
+            frenzy_caught: 0,
+            buff_caught: 0,
+            green_coin_caught: 0,
+            fingerers_state: HashMap::new(),
+            achievements_earned: HashSet::new(),
+            prestige: 0,
+            total_play_ticks: 0,
+            buffs: vec![],
+            tree: UpgradeTreeState::default(),
+        }
+    }
+
+    #[test]
+    fn v4_to_v5_promotes_f64_counters_to_mag() {
+        let v4 = GameStateV4 {
+            cuques: 1.5e30,
+            lifetime_cuques: 1.5e30,
+            best_fps: 5_000.0,
+            ..empty_v4()
+        };
+        let v5: GameStateV5 = v4.into();
+        assert_eq!(v5.version, 5);
+        // Round-trip through Mag: log10(1.5e30) ≈ 30.176.
+        assert!((v5.cuques.to_f64() - 1.5e30).abs() / 1.5e30 < 1e-12);
+        assert!((v5.best_fps.to_f64() - 5_000.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn v4_to_v5_collapses_nan_and_inf_to_zero() {
+        // The exact failure mode of the wild "broken save": cuques was
+        // serialized as 0.0 because serde refused the underlying f64::Inf.
+        // After this migration `Mag::from_f64` on any non-finite value
+        // produces `Mag::ZERO` — we never re-introduce the Inf to live
+        // state.
+        let v4 = GameStateV4 {
+            cuques: f64::INFINITY,
+            lifetime_cuques: f64::NAN,
+            best_fps: f64::NEG_INFINITY,
+            ..empty_v4()
+        };
+        let v5: GameStateV5 = v4.into();
+        assert_eq!(v5.cuques, Mag::ZERO);
+        assert_eq!(v5.lifetime_cuques, Mag::ZERO);
+        assert_eq!(v5.best_fps, Mag::ZERO);
+    }
+
+    #[test]
+    fn v5_into_current_preserves_tree_state() {
+        let mut v5: GameStateV5 = empty_v4().into();
+        v5.tree.bought.insert(TreeCoord::ORIGIN);
+        v5.tree.bought.insert(TreeCoord::new(3, -2));
+        let live = v5.into_current();
+        assert!(live.tree.bought.contains(&TreeCoord::ORIGIN));
+        assert!(live.tree.bought.contains(&TreeCoord::new(3, -2)));
+    }
+
+    #[test]
+    fn v5_serialize_huge_value_round_trips() {
+        // The blocker that motivated V5: a `Mag` with log10 past the
+        // f64-finite range needs to serialize and deserialize through
+        // the V5 frozen schema without falling back to `default()`.
+        // The `Mag` shim emits `{"log10": x}` for big values; the V5
+        // schema declares `Mag`-typed fields so the struct form is
+        // accepted.
+        let mut v5: GameStateV5 = empty_v4().into();
+        v5.cuques = Mag { log10: 600.0 };
+        v5.lifetime_cuques = Mag { log10: 1200.0 };
+        let json = serde_json::to_string(&v5).expect("serialize");
+        let parsed: GameStateV5 = serde_json::from_str(&json).expect("deserialize");
+        assert!((parsed.cuques.log10 - 600.0).abs() < 1e-9);
+        assert!((parsed.lifetime_cuques.log10 - 1200.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn v5_serialize_small_value_emits_plain_number() {
+        // For values comfortably inside `f64`, the wire format stays a
+        // plain JSON number — same shape every previous version
+        // produced. Confirms V4 readers (and humans) reading a V5 save
+        // see familiar text for typical play.
+        let mut v5: GameStateV5 = empty_v4().into();
+        v5.cuques = Mag::from_f64(12345.6);
+        let json = serde_json::to_string(&v5.cuques).expect("serialize");
+        assert!(
+            !json.contains("log10"),
+            "small Mag should serialize as a bare number, got {json}"
+        );
+    }
+}

--- a/src/sim.rs
+++ b/src/sim.rs
@@ -205,10 +205,14 @@ fn maybe_idle_clench(state: &mut GameState) {
 
 fn maybe_spawn_auto_particle(state: &mut GameState, geom: &SimGeometry) {
     let fps = state.fps();
-    if fps <= 0.0 || geom.biscuit.width < 4 || geom.biscuit.height < 4 {
+    if fps.is_zero() || geom.biscuit.width < 4 || geom.biscuit.height < 4 {
         return;
     }
-    let target_rate = fps.sqrt().clamp(0.5, 8.0);
+    // `target_rate` paces the particle spawner; once FPS is in the
+    // "many cuques per second" range it caps at 8/s and we don't care
+    // about precise sqrt math. Compute via f64 (saturating) and clamp.
+    let fps_f = fps.to_f64();
+    let target_rate = fps_f.sqrt().clamp(0.5, 8.0);
     let prob = target_rate * TICK_DT;
     let mut rng = rand::rng();
     if rng.random::<f64>() >= prob {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -240,7 +240,7 @@ pub fn draw(
         .add_modifier(Modifier::BOLD);
     let mut hud_spans: Vec<Span> = vec![
         Span::raw(format!("{}: ", lang.hud_cuques)),
-        Span::styled(format::big(state.displayed_cuques), cuques_style),
+        Span::styled(format::big_mag(state.displayed_cuques), cuques_style),
         Span::raw(format!(
             "   {}: {}",
             lang.hud_fps,
@@ -300,7 +300,7 @@ pub fn draw(
                 _ => None,
             });
             let label = match mul {
-                Some(v) => format!("  [++ {} x{} {}s]", name, v as u64, secs),
+                Some(v) => format!("  [++ {} x{} {}s]", name, v.floor_u64(), secs),
                 None => format!("  [++ {} {}s]", name, secs),
             };
             let color = match m.source {

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -40,7 +40,13 @@ pub fn draw(
     let lang = t();
     let mut lines: Vec<Line> = Vec::new();
     let visible: Vec<usize> = (0..FINGERERS.len())
-        .filter(|&i| fingerer::visible(i, state.fingerer_count_idx(i), state.lifetime_cuques))
+        .filter(|&i| {
+            fingerer::visible(
+                i,
+                state.fingerer_count_idx(i),
+                state.lifetime_cuques.to_f64(),
+            )
+        })
         .collect();
 
     for (slot, &i) in visible.iter().enumerate() {
@@ -75,7 +81,10 @@ pub fn draw(
         ]));
         lines.push(Line::from(vec![
             Span::raw(format!("    {}: {}  ", lang.owned, owned)),
-            Span::styled(format!("{} {}", lang.cost, format::big(cost)), cost_style),
+            Span::styled(
+                format!("{} {}", lang.cost, format::big_mag(cost)),
+                cost_style,
+            ),
         ]));
         // Per-fingerer mul factor from the tree (folds in any
         // `AllFingerers` contributions). The badge mirrors what the FPS
@@ -83,9 +92,16 @@ pub fn draw(
         // here that drives their income.
         let tree_contrib = state.tree_aggregate.effective_for_fingerer(i);
         let mult = tree_contrib.mul_factor;
-        let effective = k.fps_per_unit * mult;
-        let mult_tag = if mult > 1.0001 {
-            format!(" (x{:.1})", mult)
+        // For the per-row badge we want the multiplier as an f64 — the
+        // display threshold "show the badge once mult > 1.0001" makes
+        // sense in linear space and is bounded by the per-node tree
+        // caps. Pull through `to_f64`; the boundary clamp is a non-issue
+        // since the badge only renders when the value is small enough
+        // to read anyway.
+        let mult_f = mult.to_f64();
+        let effective = k.fps_per_unit * mult_f;
+        let mult_tag = if mult_f > 1.0001 {
+            format!(" (x{:.1})", mult_f)
         } else {
             String::new()
         };

--- a/src/ui/stats.rs
+++ b/src/ui/stats.rs
@@ -40,10 +40,10 @@ pub fn draw(frame: &mut Frame, area: Rect, state: &GameState) {
         ),
         (
             lang.stat_lifetime_cuques,
-            format::big(state.lifetime_cuques),
+            format::big_mag(state.lifetime_cuques),
             neutral,
         ),
-        (lang.stat_best_fps, format::rate(state.best_fps), neutral),
+        (lang.stat_best_fps, format::big_mag(state.best_fps), neutral),
         (
             lang.stat_fingerers_owned,
             format::big(state.fingerers_owned_total() as f64),

--- a/src/ui/tree.rs
+++ b/src/ui/tree.rs
@@ -171,7 +171,7 @@ fn draw_header(frame: &mut Frame, area: Rect, state: &GameState) {
     let line = Line::from(vec![
         Span::raw(format!("{}: ", lang.hud_cuques)),
         Span::styled(
-            format::big(state.displayed_cuques),
+            format::big_mag(state.displayed_cuques),
             Style::default()
                 .fg(Color::Rgb(180, 255, 180))
                 .add_modifier(StyleMod::BOLD),
@@ -216,7 +216,7 @@ struct VisibleNode {
     rarity: Rarity,
     lot: TreeCoord,
     dominant_target: Target,
-    cost: f64,
+    cost: crate::bignum::Mag,
     owned: bool,
     reachable: bool,
     affordable: bool,
@@ -493,7 +493,7 @@ fn draw_box(
                     let cost_str = if v.owned {
                         "[ owned ]".to_string()
                     } else {
-                        format::big(v.cost).to_string()
+                        format::big_mag(v.cost)
                     };
                     cost_str.chars().nth((col - 1) as usize).unwrap_or(' ')
                 } else if r_in > 0
@@ -1378,8 +1378,10 @@ fn draw_info_pane(
                         ),
                     ])
                 } else {
-                    let refund = (spec.cost * TREE_REFUND_FRACTION).floor();
-                    let loss = spec.cost - refund;
+                    let refund = spec
+                        .cost
+                        .mul(crate::bignum::Mag::from_f64(TREE_REFUND_FRACTION));
+                    let loss = spec.cost.saturating_sub(refund);
                     let label_len = refund_button_label.chars().count() as u16;
                     action_button = Some((
                         TreeButtonAction::Refund,
@@ -1407,8 +1409,8 @@ fn draw_info_pane(
                             format!(
                                 "  {}",
                                 lang.tree_refund_returns_fmt
-                                    .replacen("{}", &format::big(refund), 1)
-                                    .replacen("{}", &format::big(loss), 1)
+                                    .replacen("{}", &format::big_mag(refund), 1)
+                                    .replacen("{}", &format::big_mag(loss), 1)
                             ),
                             Style::default().fg(Color::Rgb(180, 150, 150)),
                         ),
@@ -1422,20 +1424,20 @@ fn draw_info_pane(
             } else if !affordable {
                 let need_more = lang.tree_cost_need_more_fmt.replacen(
                     "{}",
-                    &format::big(spec.cost - state.affordable_cuques()),
+                    &format::big_mag(spec.cost.saturating_sub(state.affordable_cuques())),
                     1,
                 );
                 Line::styled(
                     format!(
                         "{}{}  {}",
                         cost_label_padded,
-                        format::big(spec.cost),
+                        format::big_mag(spec.cost),
                         need_more
                     ),
                     Style::default().fg(Color::Rgb(220, 100, 100)),
                 )
             } else {
-                let cost_text = format::big(spec.cost);
+                let cost_text = format::big_mag(spec.cost);
                 // Line layout: "{cost_label_padded}{cost}   {buy_button}"
                 let prefix_cols = cost_label_padded.chars().count()
                     + cost_text.chars().count()


### PR DESCRIPTION
## Summary

- **`Mag` log-magnitude type** (`src/bignum.rs`) stores `log10(value)` in an f64. Replaces every gameplay-side counter that compounds multiplicatively (cuques, FPS, costs, tree aggregate multipliers, persisted `MulFactor` modifiers). Kills the f64-`Infinity` bug class that broke a long-haul save in triage — cuques saturated to 0, 311-trillion-x PurpleCoin modifiers, 58x-amplified GreenCoin AddPercents.
- **V5 save schema** (`src/save/versions/v5.rs`) with Mag-typed counters. V4 frozen schema untouched; `From<GameStateV4>` converts `f64 → Mag` at the migration boundary and collapses any leftover `Inf`/`NaN` to `Mag::ZERO`. Untagged serde shim on `Mag` accepts both legacy raw JSON numbers and `{"log10": x}` (huge values past `f64::MAX`), so V4-shaped saves keep loading and small V5 values still write as plain numbers.
- **Tree orphan fix**: new `reaches_origin` predicate requires a strictly-decreasing-manhattan chain of populated neighbors back to origin. `anchor_of`'s pass-3 fallback was producing closed 2-node islands (the reported "Halo of the Heel / Bless Matins at -6,-17"). Thread-local memo keeps it O(lots visited). New 40-radius BFS test asserts zero orphans (was 50+ across that region before).
- **Procgen rebalance**: per-node boon/bane magnitudes ~1000× smaller across the board; multiplicative ops (`MulFactor` / `EffectMul` / `SpawnRateMul` / `CostMul`) another 100× tighter on top so a 100k-deep stack stays in single-digit-× multiplier territory (was overflowing f64 around stack 1.7k). `AddPercent` / `FlatAdd` kept at 1000× because they're linear, not compounding. `NODE_COST_GROWTH` 1.75 → 2.5 stretches the cost ramp.
- **Infinite alphabetic suffix tail** past Decillion in `format::big_mag` (`aa..zz`, `Aa..Zz`, `aaa..zzz`, …). Precision-aware `mul_magnitude` / `percent_magnitude` / `flat_magnitude` helpers so per-node `×1.0000004` renders with its meaningful digits in the info pane instead of collapsing to `×1.00`. `?` is now strictly an `Inf`/`NaN` sentinel.
- **CI gate widened**: `cargo clippy --all-targets -- -D warnings` (was lib-only), so test-side lint regressions don't slip past CI in future PRs.

## Test plan

- [ ] CI green: `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test`, the 4-target build matrix, wasm32 check.
- [ ] Smoke test on a fresh save (TUI): buy fingerers, open tree, buy a connected node, refund it back. Info pane shows tiny per-node values like `×1.00000145 effect on Frenzy reward`.
- [ ] Stress test on the V4 broken save (the triage fixture, removed from repo but preserved in commit history): loads cleanly under V5, gameplay accrues into Mag-space numbers in alpha-suffix territory (`oo` / `dm` / `bq`), no `?` rendered anywhere.
- [ ] Long playtest: 100+ stacked PurpleCoin Buffs on random fingerers. FPS spikes to ~5T, decays cleanly as buffs expire over 30s, no `?` rendered.
- [ ] Cross-version save load: V1 / V2 / V3 / V4 saves all migrate cleanly to V5. New unit test `v4_json_with_plain_number_fields_still_loads_under_v5` covers the wire-format compatibility.
- [ ] Huge-Mag round-trip: state with `cuques.log10 > 300` serializes (struct form) and reloads (struct form accepted by V5 schema) without falling back to `default()`. Regression test for the V5-blocker found in adversarial review.
- [ ] Prestige `earned` matches legacy `floor(sqrt(lifetime/1e6))` at integer-tier boundaries — `lifetime=25M → 5`, `81M → 9`, etc. Regression test for an off-by-one round-trip-precision bug found in review.