### PR TITLE
fix(ui/tree): no fingerer-ring bleed at the bottom of the modal

### DIFF
--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -384,8 +384,11 @@ pub fn draw(
         Mode::Tree => {
             // Full-screen modal — the tree renderer takes the WHOLE frame
             // area, not just the sidebar column, so the player gets the
-            // full canvas to pan around.
-            let out = tree::draw(frame, area, state, mouse_pos, tree_render);
+            // full canvas to pan around. Pass the live `help_height` so
+            // the modal covers exactly down to the help bar; hardcoding
+            // a `2` here used to leak a one-row strip of biscuit when
+            // the help text wrapped to a single row.
+            let out = tree::draw(frame, area, state, mouse_pos, tree_render, help_height);
             tree_node_rects = out.node_rects;
             tree_action_button = out.action_button;
         }

--- a/src/ui/tree.rs
+++ b/src/ui/tree.rs
@@ -55,10 +55,6 @@ const PAN_SNAP_EPSILON: f32 = 0.5;
 /// of edges.
 const VISIBLE_RADIUS_LOTS: i32 = 6;
 
-/// Help bar height reserved at the bottom — `ui::mod.rs` rendered the help
-/// text there before we got the frame, so we leave those rows alone.
-const HELP_BAR_HEIGHT: u16 = 2;
-
 const INFO_PANE_HEIGHT: u16 = 8;
 const HEADER_HEIGHT: u16 = 3;
 
@@ -68,8 +64,16 @@ pub fn draw(
     state: &GameState,
     mouse_pos: Option<(u16, u16)>,
     tree_render: &mut TreeRenderState,
+    help_bar_height: u16,
 ) -> TreeDrawOutput {
-    let modal_h = area.height.saturating_sub(HELP_BAR_HEIGHT);
+    // `help_bar_height` is the actual `wrapped_height(help_text, ...)`
+    // ui::mod.rs reserved for the bottom help row(s). When the help
+    // text fits in a single row it's 1, otherwise 2; passing the live
+    // value lets the modal hug exactly the row above the help bar,
+    // so the biscuit + hands rendered into `left[1]` underneath stay
+    // fully covered. A previous hardcoded `2` left a one-row strip
+    // exposed whenever `help_bar_height == 1`.
+    let modal_h = area.height.saturating_sub(help_bar_height);
     if modal_h < HEADER_HEIGHT + INFO_PANE_HEIGHT + 4 {
         // Terminal too small; bail out gracefully.
         return TreeDrawOutput {


### PR DESCRIPTION
## Summary

The tree modal hardcoded `HELP_BAR_HEIGHT = 2` and shrunk its own rect to `area.height - 2`, but the help bar actually uses `wrapped_height(help_text, …)` which is **1** on wide-enough terminals where the help text fits in a single row. When that happens, the modal stops 2 rows from the bottom but the help bar only paints the last 1 — leaving a one-row strip where the biscuit + orbiting fingerers underneath show through.

Fix: pass the live `help_height` from `ui::mod.rs` into `tree::draw` so the modal hugs exactly the row above the actual help bar. The hardcoded constant goes away.

## Reproduction (pre-fix)

Run at a wide terminal (≥ ~145 columns wide) where the help text fits on one line, with many owned fingerers so the orbital ring extends to the bottom of the play area. Open the tree (`t`). The bottom row of the orbit (Index Finger `>>`, Whole Hand `[]`, Latex Glove `<>` glyphs etc.) is visible just above the help bar.

## Test plan

- [ ] Open tree at 220x40 with ~40 owned of every tier — no fingerer glyphs visible between the info pane and the help bar.
- [ ] Open tree at 160x50 (narrower, help wraps to 2 rows) — no regression, same coverage as before.
- [ ] All previous tests still pass: `cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`.